### PR TITLE
Add Mesos host port option

### DIFF
--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -3,7 +3,7 @@ require 'formula'
 class NmesosCli < Formula
   desc "Nmesos is a CLI tool to deploy into Mesos."
   homepage "https://github.com/Nitro/nmesos"
-  url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.1.4/nmesos-cli-0.1.4.tgz"
+  url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.1.5/nmesos-cli-0.1.5.tgz"
 
   def install
     bin.install 'nmesos'

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name in ThisBuild := "nmesos"
 organization in ThisBuild := "com.gonitro"
-version in ThisBuild := "0.1.4"
+version in ThisBuild := "0.1.5"
 
 lazy val cli = Project("nmesos-cli", file("cli"))
   .dependsOn(shared)

--- a/docs/examples/example-service.yml
+++ b/docs/examples/example-service.yml
@@ -14,8 +14,8 @@ common:
     #forcePullImage: true                    # Optional to force pull (default false)
 
     ports:
-      - 8080      # Exposed port by the container (Mesos will auto assign a external port)
-      - 9000:1200 # Require Mesos to assign a specific port (<container_port>:<host_port>)
+      - 8080       # Exposed port by the container (Mesos will auto assign a external port)
+      - 9000:12000 # Require Mesos to assign a specific port (<container_port>:<host_port>)
 
     volumes:
       - /tmp/foo:/tmp/foo  #  (HOST:CONTAINER) with default rw or (HOST:CONTAINER:rw)

--- a/docs/examples/example-service.yml
+++ b/docs/examples/example-service.yml
@@ -14,7 +14,8 @@ common:
     #forcePullImage: true                    # Optional to force pull (default false)
 
     ports:
-      - 8080 # Exposed port by the container (Mesos will auto assign a external port)
+      - 8080      # Exposed port by the container (Mesos will auto assign a external port)
+      - 9000:1200 # Require Mesos to assign a specific port (<container_port>:<host_port>)
 
     volumes:
       - /tmp/foo:/tmp/foo  #  (HOST:CONTAINER) with default rw or (HOST:CONTAINER:rw)
@@ -31,6 +32,9 @@ common:
     autoAdvanceDeploySteps: true    # false to have Canary deployments.
     deployStepWaitTimeMs: 1000      # Time to wait between deployments
     healthcheckUri: "/hello"        # Used for singularity to determine if a deploy was success
+    healthcheckPortIndex: 1         # (Optional) Specify the zero-based index of the exposed port
+                                    #   which should be used for the health check. Otherwise,
+                                    #   Singularity will use the first available one
 
 environments:
   dev:

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -17,7 +17,7 @@ object YamlParserHelper {
       }
 
       override def write(obj: PortMap): YamlValue = {
-        YamlString(obj.containerPort.toString + ":" + obj.hostPort.toString)
+        YamlString(s"${obj.containerPort}:${obj.hostPort}")
       }
     }
 

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -19,11 +19,11 @@ object YamlParserHelper {
           case _ => deserializationError("Failed to deserialize port map specification")
         }
         case _ => deserializationError("Failed to deserialize port specification")
-
       }
 
-      override def write(obj: PortMap): YamlValue = {
-        YamlString(s"${obj.containerPort}:${obj.hostPort}")
+      override def write(portMap: PortMap): YamlValue = portMap.hostPort match {
+        case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}")
+        case None => YamlNumber(portMap.containerPort)
       }
     }
 

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -1,7 +1,7 @@
 package com.nitro.nmesos.config
 
 import com.nitro.nmesos.config.model._
-import net.jcazevedo.moultingyaml.{ DefaultYamlProtocol, YamlArray, YamlBoolean, YamlDate, YamlNull, YamlNumber, YamlObject, YamlSet, YamlString, YamlValue }
+import net.jcazevedo.moultingyaml.{ DefaultYamlProtocol, YamlArray, YamlBoolean, YamlDate, YamlFormat, YamlNull, YamlNumber, YamlObject, YamlSet, YamlString, YamlValue, deserializationError }
 
 import scala.annotation.tailrec
 
@@ -10,6 +10,17 @@ object YamlParserHelper {
 
   // boilerplate to parse our custom case class
   object YamlCustomProtocol extends DefaultYamlProtocol {
+    implicit val PortMapYamlFormat = new YamlFormat[PortMap] {
+      override def read(yaml: YamlValue): PortMap = {
+        val Array(containerPort, hostPort) = yaml.convertTo[String].split(":").map(_.toInt)
+        PortMap(containerPort, hostPort)
+      }
+
+      override def write(obj: PortMap): YamlValue = {
+        YamlString(obj.containerPort.toString + ":" + obj.hostPort.toString)
+      }
+    }
+
     implicit val resourcesFormat = yamlFormat3(Resources)
     implicit val containerFormat = yamlFormat9(Container)
     implicit val singularityFormat = yamlFormat9(SingularityConf)

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -40,14 +40,14 @@ object model {
 
   case class PortMap(
     containerPort: Int,
-    hostPort: Int
+    hostPort: Option[Int]
   )
 
   case class Container(
     image: String,
     command: Option[String],
     forcePullImage: Option[Boolean],
-    ports: Option[Seq[Either[Int, PortMap]]],
+    ports: Option[Seq[PortMap]],
     labels: Option[Map[String, String]],
     env_vars: Option[Map[String, String]],
     volumes: Option[Seq[String]],

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -38,11 +38,16 @@ object model {
     instances: Option[Int]
   )
 
+  case class PortMap(
+    containerPort: Int,
+    hostPort: Int
+  )
+
   case class Container(
     image: String,
     command: Option[String],
     forcePullImage: Option[Boolean],
-    ports: Option[Seq[Int]],
+    ports: Option[Seq[Either[Int, PortMap]]],
     labels: Option[Map[String, String]],
     env_vars: Option[Map[String, String]],
     volumes: Option[Seq[String]],

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
@@ -31,20 +31,20 @@ object ModelConversions {
     }
 
     val portMappings = containerPorts.zipWithIndex.map {
-      case (port, index) =>
-        port match {
-          case Left(dynamicPort) => SingularityDockerPortMapping(
-            containerPort = dynamicPort,
+      case (portMap, index) =>
+        portMap.hostPort match {
+          case Some(hostPort) => SingularityDockerPortMapping(
+            containerPort = portMap.containerPort,
+            containerPortType = "LITERAL",
+            hostPort = hostPort,
+            hostPortType = "LITERAL",
+            protocol = "tcp"
+          )
+          case None => SingularityDockerPortMapping(
+            containerPort = portMap.containerPort,
             containerPortType = "LITERAL",
             hostPort = index, // When using Literal Host (PORT0, PORT1, PORT2)
             hostPortType = "FROM_OFFER",
-            protocol = "tcp"
-          )
-          case Right(portMap) => SingularityDockerPortMapping(
-            containerPort = portMap.containerPort,
-            containerPortType = "LITERAL",
-            hostPort = portMap.hostPort,
-            hostPortType = "LITERAL",
             protocol = "tcp"
           )
         }

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
@@ -32,13 +32,22 @@ object ModelConversions {
 
     val portMappings = containerPorts.zipWithIndex.map {
       case (port, index) =>
-        SingularityDockerPortMapping(
-          containerPort = port,
-          hostPortType = "FROM_OFFER",
-          containerPortType = "LITERAL",
-          hostPort = index, // When using Literal Host (PORT0, PORT1, PORT2)
-          protocol = "tcp"
-        )
+        port match {
+          case Left(dynamicPort) => SingularityDockerPortMapping(
+            containerPort = dynamicPort,
+            containerPortType = "LITERAL",
+            hostPort = index, // When using Literal Host (PORT0, PORT1, PORT2)
+            hostPortType = "FROM_OFFER",
+            protocol = "tcp"
+          )
+          case Right(portMap) => SingularityDockerPortMapping(
+            containerPort = portMap.containerPort,
+            containerPortType = "LITERAL",
+            hostPort = portMap.hostPort,
+            hostPortType = "LITERAL",
+            protocol = "tcp"
+          )
+        }
     }
 
     val labels = config.environment.container.labels

--- a/shared/src/test/resources/config/example-port-config.yml
+++ b/shared/src/test/resources/config/example-port-config.yml
@@ -1,0 +1,20 @@
+## Example config for testing
+nmesos_version: '0.0.1' ## Min nmesos required to execute this config
+
+common:
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.1
+    memoryMb: 64
+
+  container:
+    image: hubspot/singularity-test-service # Docker repo/image without the tag
+
+    ports:
+      - 9000:12000
+      - 8080
+
+environments:
+  dev:
+    singularity:
+      url: "http://192.168.99.100:7099/singularity"

--- a/shared/src/test/resources/config/invalid-port-config.yml
+++ b/shared/src/test/resources/config/invalid-port-config.yml
@@ -11,8 +11,7 @@ common:
     image: hubspot/singularity-test-service # Docker repo/image without the tag
 
     ports:
-      - 9000:12000
-      - 8080
+      - 8080:
 
 environments:
   dev:

--- a/shared/src/test/resources/config/invalid-port-map-config.yml
+++ b/shared/src/test/resources/config/invalid-port-map-config.yml
@@ -11,8 +11,7 @@ common:
     image: hubspot/singularity-test-service # Docker repo/image without the tag
 
     ports:
-      - 9000:12000
-      - 8080
+      - 9000:12000:23000
 
 environments:
   dev:

--- a/shared/src/test/resources/config/invalid-random.yml
+++ b/shared/src/test/resources/config/invalid-random.yml
@@ -1,0 +1,13 @@
+
+
+common: &common
+  image: gonitro/test
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.5
+    memoryMb: 2048
+    diskMb: 0
+ WTF!
+environments:
+  dev:
+    <<: *common

--- a/shared/src/test/resources/config/invalid-with-incomplete-conf.yml
+++ b/shared/src/test/resources/config/invalid-with-incomplete-conf.yml
@@ -1,0 +1,14 @@
+
+
+common: &common
+  image: gonitro/test
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.5
+    memoryMb: 2048
+    diskMb: 0
+environments:
+  dev:
+    <<: *common
+  prod:
+    # image and all other required parameters are missing here

--- a/shared/src/test/resources/config/invalid-without-version.yml
+++ b/shared/src/test/resources/config/invalid-without-version.yml
@@ -1,0 +1,12 @@
+
+
+common: &common
+  image: gonitro/test
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.5
+    memoryMb: 2048
+    diskMb: 0
+environments:
+  dev:
+    <<: *common

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -2,7 +2,7 @@ package com.nitro.nmesos.config
 
 import com.nitro.nmesos.util.InfoLogger
 import com.nitro.nmesos.config.YamlParser._
-import com.nitro.nmesos.config.model.ExecutorConf
+import com.nitro.nmesos.config.model.{ ExecutorConf, PortMap }
 import org.specs2.mutable.Specification
 
 import scala.io.Source
@@ -56,6 +56,16 @@ class YmlSpec extends Specification with YmlTestFixtures {
       modelConfig.environments("dev").singularity.slavePlacement should be equalTo (Some("SPREAD_ALL_SLAVES"))
     }
 
+    "Parse the port config from a valid Yaml file" in {
+      val parsedYaml = YamlParser.parse(YamlExamplePortConfig, InfoLogger)
+      parsedYaml should beAnInstanceOf[ValidYaml]
+
+      val conf = parsedYaml.asInstanceOf[ValidYaml].config
+      conf.environments("dev").container.ports must beSome.which(_.map(element => element match {
+        case Left(port) => port must beEqualTo(8080)
+        case Right(portMap) => portMap must beEqualTo(PortMap(9000, 12000))
+      }))
+    }
   }
 }
 
@@ -122,4 +132,6 @@ trait YmlTestFixtures {
   def YamlExampleExecutorEnvs = Source.fromURL(getClass.getResource("/config/example-config-with-executor.yml")).mkString
 
   def YamlJobExampleValid = Source.fromURL(getClass.getResource("/config/example-without-optional-config.yml")).mkString
+
+  def YamlExamplePortConfig = Source.fromURL(getClass.getResource("/config/example-port-config.yml")).mkString
 }

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -34,7 +34,6 @@ class YmlSpec extends Specification with YmlTestFixtures {
     }
 
     "return a valid config from a valid Yaml with optional singularity config missing" in {
-      val temp = YamlParser.parse(YamlJobExampleValid, InfoLogger).asInstanceOf[ValidYaml].config
       YamlParser.parse(YamlJobExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
     }
 


### PR DESCRIPTION
- Allow the user to specify a fixed host port which Mesos needs to allocate for an exposed container port. The format is: <container_port>:<host_port>
- Add unit test
- Also update docs