### PR TITLE
Add protocol specification

### DIFF
--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -3,7 +3,7 @@ require 'formula'
 class NmesosCli < Formula
   desc "Nmesos is a CLI tool to deploy into Mesos."
   homepage "https://github.com/Nitro/nmesos"
-  url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.1.5/nmesos-cli-0.1.5.tgz"
+  url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.1.6/nmesos-cli-0.1.6.tgz"
 
   def install
     bin.install 'nmesos'

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name in ThisBuild := "nmesos"
 organization in ThisBuild := "com.gonitro"
-version in ThisBuild := "0.1.5"
+version in ThisBuild := "0.1.6"
 
 lazy val cli = Project("nmesos-cli", file("cli"))
   .dependsOn(shared)

--- a/docs/examples/example-service.yml
+++ b/docs/examples/example-service.yml
@@ -14,11 +14,14 @@ common:
     #forcePullImage: true                    # Optional to force pull (default false)
 
     ports:
-      - 8080       # Exposed port by the container (Mesos will auto assign a external port)
-      - 9000:12000 # Require Mesos to assign a specific fixed port (<container_port>:<host_port>)
-                   # Note: you may notice that Singularity automatically allocates an extra
-                   #       external port for each requested fixed port. This seems to be a
-                   #       bug in Singularity.
+      - 8080               # Exposed port by the container (Mesos will auto assign a external port)
+      - 9000:12000         # Require Mesos to assign a specific fixed port (<container_port>:<host_port>)
+                           # Note: you may notice that Singularity automatically allocates an extra
+                           #       external port for each requested fixed port. This seems to be a
+                           #       bug in Singularity.
+      - 9100/udp           # /udp instructs the executor to open this port for the UDP protocol instead of the default (TCP)
+      - 9101/tcp,udp       # Accept both TCP and UDP protocols
+      - 9102:13000/tcp,udp # This also works
 
     volumes:
       - /tmp/foo:/tmp/foo  #  (HOST:CONTAINER) with default rw or (HOST:CONTAINER:rw)

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -7,23 +7,45 @@ import scala.annotation.tailrec
 
 // Yaml parser Boilerplate
 object YamlParserHelper {
+  def parsePortMap(portMap: String, protocols: String): PortMap = {
+    val (containerPort, hostPort) = portMap.split(":").map(_.toInt).toList match {
+      case containerPort :: Nil => (containerPort, None)
+      case containerPort :: hostPort :: Nil => (containerPort, Some(hostPort))
+      case _ => deserializationError("Failed to deserialize the port map specification")
+    }
+
+    val protocolList = protocols.split(",").filter(_.trim.nonEmpty).toList match {
+      case Nil => Nil
+      case _@ protocols => protocols
+    }
+
+    PortMap(containerPort, hostPort, protocolList)
+  }
 
   // boilerplate to parse our custom case class
   object YamlCustomProtocol extends DefaultYamlProtocol {
     implicit val PortMapYamlFormat = new YamlFormat[PortMap] {
       override def read(yaml: YamlValue): PortMap = yaml match {
-        case YamlNumber(_) => PortMap(yaml.convertTo[Int], None)
-        case YamlString(_) => yaml.convertTo[String].split(":").map(_.toInt).toList match {
-          case containerPort :: Nil => PortMap(containerPort, None)
-          case containerPort :: hostPort :: Nil => PortMap(containerPort, Some(hostPort))
-          case _ => deserializationError("Failed to deserialize port map specification")
+        case YamlNumber(_) => PortMap(yaml.convertTo[Int], None, Nil)
+        case YamlString(_) => yaml.convertTo[String].split("/").toList match {
+          case portMap :: Nil => parsePortMap(portMap, "")
+          case portMap :: protocols :: Nil => parsePortMap(portMap, protocols)
+          case _ => deserializationError("Failed to deserialize the port map specification")
         }
-        case _ => deserializationError("Failed to deserialize port specification")
+        case _ => deserializationError("Failed to deserialize the port specification")
       }
 
-      override def write(portMap: PortMap): YamlValue = portMap.hostPort match {
-        case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}")
-        case None => YamlNumber(portMap.containerPort)
+      override def write(portMap: PortMap): YamlValue = {
+        portMap.protocols match {
+          case Nil => portMap.hostPort match {
+            case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}")
+            case None => YamlNumber(portMap.containerPort)
+          }
+          case _@ protocols => portMap.hostPort match {
+            case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}/${protocols.mkString(",")}")
+            case None => YamlString(s"${portMap.containerPort}/${protocols.mkString(",")}")
+          }
+        }
       }
     }
 

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -41,7 +41,7 @@ object model {
   case class PortMap(
     containerPort: Int,
     hostPort: Option[Int],
-    protocols: Seq[String]
+    protocols: Option[String]
   )
 
   case class Container(

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -40,7 +40,8 @@ object model {
 
   case class PortMap(
     containerPort: Int,
-    hostPort: Option[Int]
+    hostPort: Option[Int],
+    protocols: Seq[String]
   )
 
   case class Container(

--- a/shared/src/test/resources/config/example-port-config-all-variations.yml
+++ b/shared/src/test/resources/config/example-port-config-all-variations.yml
@@ -11,9 +11,12 @@ common:
     image: hubspot/singularity-test-service # Docker repo/image without the tag
 
     ports:
-      - 6060/udp,tcp
       - 8080
+      - 8081/udp
+      - 8082/tcp.udp
       - 9000:12000
+      - 9001:12001/udp
+      - 9002:12002/tcp,udp
 
 environments:
   dev:

--- a/shared/src/test/resources/config/example-port-config-all-variations.yml
+++ b/shared/src/test/resources/config/example-port-config-all-variations.yml
@@ -13,7 +13,7 @@ common:
     ports:
       - 8080
       - 8081/udp
-      - 8082/tcp.udp
+      - 8082/tcp,udp
       - 9000:12000
       - 9001:12001/udp
       - 9002:12002/tcp,udp

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -63,13 +63,12 @@ class YmlSpec extends Specification with YmlTestFixtures {
 
       val conf = parsedYaml.asInstanceOf[ValidYaml].config
       conf.environments("dev").container.ports must beSome.which(_.map(portMap => portMap.hostPort match {
-        case Some(hostPort) => portMap should be equalTo PortMap(9000, Option(12000), Nil)
+        case Some(hostPort) => portMap should be equalTo PortMap(9000, Option(12000), None)
         case None => portMap.protocols match {
-          case Nil => portMap.containerPort should be equalTo 8080
-          case protocolA :: protocolB :: Nil => {
+          case None => portMap.containerPort should be equalTo 8080
+          case Some(protocols) => {
             portMap.containerPort should be equalTo 6060
-            protocolA mustEqual "udp"
-            protocolB mustEqual "tcp"
+            protocols mustEqual "udp,tcp"
           }
         }
       }))
@@ -108,7 +107,7 @@ trait YmlTestFixtures {
       |      ports:
       |      - 8080
       |      - 8081/udp
-      |      - 8082/tcp.udp
+      |      - 8082/tcp,udp
       |      - 9000:12000
       |      - 9001:12001/udp
       |      - 9002:12002/tcp,udp


### PR DESCRIPTION
- Allow the user to specify the protocol(s) which should be supported through the exposed port. The format is: `<container_port>/tcp` or `<container_port>:<host_port>/tcp` or `<container_port>/tcp,udp` or `<container_port>:<host_port>/tcp,udp` etc.
- Add unit tests
- Also update docs
- And bump up the version...