### PR TITLE
Add sha256 in Forumula to fix integrity check warning

### DIFF
--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -4,6 +4,7 @@ class NmesosCli < Formula
   desc "Nmesos is a CLI tool to deploy into Mesos."
   homepage "https://github.com/Nitro/nmesos"
   url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.1.6/nmesos-cli-0.1.6.tgz"
+  sha256 "464fd37a923f062bdb9ee0ee414cc11010018765b0f501d8c5b125b85e5052d1"
 
   def install
     bin.install 'nmesos'

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,5 +18,8 @@ sbt clean "++2.12.1 nmesos-shared/publishLocal"  "++2.12.1 nmesos-cli/assembly" 
 
 ## Release a brew update
 
-Update the Formula `nmesos-cli.rb` with the new public url 
-and push the changes to the Master branch.
+Update the Formula `nmesos-cli.rb`
+1. with the new public url
+2. with the new sha256
+    `shasum -a 256 nmesos-cli-X.Y.Z.tgz`
+3. push the changes to the `master` branch


### PR DESCRIPTION
For each Bump version, this sha256 need to be updated with the correct
value of the new tarball. In order to compute the sum, use the following
command:

```
shasum -a 256 nmesos-cli-X.Y.Z.tgz
```