### PR TITLE
Check only Mesos containers

### DIFF
--- a/shared/src/main/scala/com/nitro/nmesos/commands/VerifyEnvCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/VerifyEnvCommand.scala
@@ -92,7 +92,7 @@ trait VerifyContainers {
         .flatMap(_.healthy)
         .map(_.id)
 
-      val runningContainerTaskId = info.containers.map(_.taskId)
+      val runningContainerTaskId = info.containers.filter(_.name.startsWith("mesos-")).map(_.taskId)
       val orphans = runningContainerTaskId.diff(mesosTasksId)
 
       print(info, mesosTasksId, orphans)


### PR DESCRIPTION
During `nmesos verify`, we want to skip validating containers that haven't been started by nmesos.