### PR TITLE
Add bash completion for nmesos

### DIFF
--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -8,5 +8,6 @@ class NmesosCli < Formula
 
   def install
     bin.install 'nmesos'
+    bash_completion.install 'contrib/etc/bash_completion.d/nmesos'
   end
 end

--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -6,8 +6,15 @@ class NmesosCli < Formula
   url "https://s3-us-west-2.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.2.7/nmesos-cli-0.2.7.tgz"
   sha256 "c456e01c279bd4d7bd68781411267811da637ad9e7d5c99c2f33c57a30c49582"
 
+  option "with-bash-completion", "Install bash-completion"
+
+  depends_on "bash-completion" => :optional
+
   def install
+    if build.with? "bash-completion"
+      bash_completion.install "./contrib/etc/bash_completion.d/nmesos"
+    end
+
     bin.install 'nmesos'
-    bash_completion.install 'contrib/etc/bash_completion.d/nmesos'
   end
 end

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Uninstall Nmesos cli:
 brew uninstall nmesos-cli
 ```
 
+## Bash Completion support
+
+If you want to install the support for the
+[bash-completion](contrib/etc/bash_completion.d/nmesos), you can use the brew
+option `--with-bash-completion` when installing:
+
+```
+brew install --with-bash-completion nmesos-cli
+```
 
 ## Other Comands
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name in ThisBuild := "nmesos"
 organization in ThisBuild := "com.gonitro"
-version in ThisBuild := "0.2.7"
+version in ThisBuild := "0.2.8"
 scalaVersion in ThisBuild := "2.12.1"
 
 lazy val cli = Project("nmesos-cli", file("cli"))

--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -24,6 +24,7 @@ packageName in Universal := "nmesos-cli-" + version.value
 mappings in Universal in packageZipTarball := {
   Seq(
     file("README.md") -> "README.md",
+    file("contrib/etc/bash_completion.d/nmesos") -> "contrib/etc/bash_completion.d/nmesos",
     file((assemblyOutputPath in assembly).value.getPath) -> "nmesos"
   )
 }

--- a/contrib/etc/bash_completion.d/nmesos
+++ b/contrib/etc/bash_completion.d/nmesos
@@ -1,0 +1,46 @@
+_nmesos() {
+    local cur prev commands global_opts opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    commands="release scale check verify"
+    global_opts="--verbose -v --noformat --help -h"
+
+    if [ $COMP_CWORD == 1 ] ; then
+        COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+        return 0
+    fi
+
+    if [[ ${cur} == -* ]] ; then
+        case "$prev" in
+            "release")
+                opts="--environment -e --tag -t --force -f --dryrun -n ${global_opts}"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                return 0
+                ;;
+            "scale")
+                opts="--environment -e --dryrun -n ${global_opts}"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                return 0
+                ;;
+            "check")
+                opts="--environment -e ${global_opts}"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                return 0
+                ;;
+            "verify")
+                opts="--singularity -s ${global_opts}"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                return 0
+                ;;
+            *)
+                opts="${global_opts}"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                return 0
+                ;;
+        esac
+    fi
+}
+
+complete -F _nmesos nmesos


### PR DESCRIPTION
This change will add bash completion support for our Nitro Mesos Command line tools. It's handy for auto completing the cli parameters.

TODO:
- [x] Update Readme.md with `bash-completion` setup instruction
- [x] Formula options?