### PR TITLE
Support all the request types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name in ThisBuild := "nmesos"
 organization in ThisBuild := "com.gonitro"
-version in ThisBuild := "0.2.9"
+version in ThisBuild := "0.2.11"
 scalaVersion in ThisBuild := "2.12.1"
 
 lazy val cli = Project("nmesos-cli", file("cli"))

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -46,7 +46,7 @@ object YamlParserHelper {
 
     implicit val resourcesFormat = yamlFormat3(Resources)
     implicit val containerFormat = yamlFormat9(Container)
-    implicit val singularityFormat = yamlFormat14(SingularityConf)
+    implicit val singularityFormat = yamlFormat15(SingularityConf)
     implicit val executorFormat = yamlFormat2(ExecutorConf)
     implicit val environmentFormat = yamlFormat4(Environment)
     implicit val configFormat = yamlFormat2(Config)

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -53,6 +53,7 @@ object model {
   case class SingularityConf(
     url: String,
     schedule: Option[String],
+    requestType: Option[String],
     deployInstanceCountPerStep: Option[Int],
     deployStepWaitTimeMs: Option[Int],
     deployHealthTimeoutSeconds: Option[Int],

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
@@ -98,7 +98,13 @@ object ModelConversions {
   }
 
   def toRequestType(config: CmdConfig): String = {
-    if (config.environment.singularity.schedule.isDefined) "SCHEDULED" else "SERVICE"
+    if (config.environment.singularity.requestType.isDefined) {
+      config.environment.singularity.requestType.get
+    } else if (config.environment.singularity.schedule.isDefined) {
+      "SCHEDULED"
+    } else {
+      "SERVICE"
+    }
   }
 
   type DeployId = String


### PR DESCRIPTION
This adds basic support for the other Singularity request types that aren't either `SERVICE` or `SCHEDULED`. This has been tested with `RUN_ONCE` and works as expected.

I'm sure there is a more correct way to write this in Scala, but this appears to work. This not an accompanying test because I wasn't up to speed enough to write it.