### PR TITLE
Check for missing env_var keys and log a warning block for missing keys

### DIFF
--- a/shared/src/test/resources/config/example-config-with-feature-toggles-for-one-environment.yml
+++ b/shared/src/test/resources/config/example-config-with-feature-toggles-for-one-environment.yml
@@ -1,0 +1,60 @@
+## Example config for testing
+nmesos_version: '0.0.1' ## Min nmesos required to execute this config
+
+common:
+
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.1
+    memoryMb: 64
+
+  container:
+
+    image: hubspot/singularity-test-service # Docker repo/image without the tag
+    forcePullImage: true                    # Optional to force pull (default false)
+    ports:
+      - 8080 # Exposed port by the container (Mesos will auto assign a external port)
+
+    volumes:
+      - /tmp/foo:/tmp/foo  #  (HOST:CONTAINER) with default rw or (HOST:CONTAINER:rw)
+
+    labels:
+      ServiceName: "exampleServer"
+      ## Sidecar config
+      HealthCheck: "HttpGet"
+      HealthCheckArgs: "http://{{ host }}:{{ tcp 8080 }}/hello"
+
+    env_vars:
+      NEW_RELIC_LICENSE_KEY: "xxxxx"
+      JAVA_OPTS: >
+        -Xms64m
+        -Xmx64m
+
+    extraDockerConf:
+      network: HOST
+      dockerParameters:
+        cap-add: NET_ADMIN
+
+  singularity:
+    deployInstanceCountPerStep: 1   # Number of instances deployed at once.
+    autoAdvanceDeploySteps: true    # false to have Canary deployments.
+    deployStepWaitTimeMs: 1000      # Time to wait between deployments
+    healthcheckUri: "/hello"  # Used for singularity to determine if a deploy was success
+    slavePlacement: "SPREAD_ALL_SLAVES"
+    requiredRole: "OPS"
+
+  ## Optional configuration to define environments variables to be passed to the Mesos executor
+  executor:
+    customExecutorCmd: "/opt/mesos/executor.sh"   # Optional custom Mesos Executor.
+    env_vars:
+      EXECUTOR_SIDECAR_DISCOVER: "false" # Default true, false => the executor will not healthcheck
+      EXECUTOR_SIDECAR_BACKOFF: "20m"    # default 1m
+
+environments:
+  dev:
+    singularity:
+      url: "http://test"
+    container:
+      env_vars:
+        foo: "bar"
+        foofoo: "barbar"

--- a/shared/src/test/resources/config/example-config-with-missing-feature-toggles.yml
+++ b/shared/src/test/resources/config/example-config-with-missing-feature-toggles.yml
@@ -1,0 +1,79 @@
+## Example config for testing
+nmesos_version: '0.0.1' ## Min nmesos required to execute this config
+
+common:
+
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.1
+    memoryMb: 64
+
+  container:
+
+    image: hubspot/singularity-test-service # Docker repo/image without the tag
+    forcePullImage: true                    # Optional to force pull (default false)
+    ports:
+      - 8080 # Exposed port by the container (Mesos will auto assign a external port)
+
+    volumes:
+      - /tmp/foo:/tmp/foo  #  (HOST:CONTAINER) with default rw or (HOST:CONTAINER:rw)
+
+    labels:
+      ServiceName: "exampleServer"
+      ## Sidecar config
+      HealthCheck: "HttpGet"
+      HealthCheckArgs: "http://{{ host }}:{{ tcp 8080 }}/hello"
+
+    env_vars:
+      NEW_RELIC_LICENSE_KEY: "xxxxx"
+      JAVA_OPTS: >
+        -Xms64m
+        -Xmx64m
+
+    extraDockerConf:
+      network: HOST
+      dockerParameters:
+        cap-add: NET_ADMIN
+
+  singularity:
+    deployInstanceCountPerStep: 1   # Number of instances deployed at once.
+    autoAdvanceDeploySteps: true    # false to have Canary deployments.
+    deployStepWaitTimeMs: 1000      # Time to wait between deployments
+    healthcheckUri: "/hello"  # Used for singularity to determine if a deploy was success
+    slavePlacement: "SPREAD_ALL_SLAVES"
+    requiredRole: "OPS"
+
+  ## Optional configuration to define environments variables to be passed to the Mesos executor
+  executor:
+    customExecutorCmd: "/opt/mesos/executor.sh"   # Optional custom Mesos Executor.
+    env_vars:
+      EXECUTOR_SIDECAR_DISCOVER: "false" # Default true, false => the executor will not healthcheck
+      EXECUTOR_SIDECAR_BACKOFF: "20m"    # default 1m
+
+environments:
+  dev:
+    singularity:
+      url: "http://test"
+    container:
+      env_vars:
+        all_envs: "something"
+        dev_and_prod: "something"
+        only_dev: "something"
+
+  prod:
+    singularity:
+      url: "http://testprod"
+    container:
+      env_vars:
+        all_envs: "something"
+        dev_and_prod: "something"
+        only_prod: "something"
+
+
+  test:
+    singularity:
+      url: "http://testprod"
+    container:
+      env_vars:
+        all_envs: "something"
+        only_test: "something"

--- a/shared/src/test/scala/com/nitro/nmesos/config/ConfigReaderSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/ConfigReaderSpec.scala
@@ -1,0 +1,34 @@
+package com.nitro.nmesos.config
+
+import com.nitro.nmesos.config.YamlParser.ValidYaml
+import com.nitro.nmesos.util.InfoLogger
+import org.specs2.mutable.Specification
+
+import scala.io.Source
+
+class ConfigReaderSpec extends Specification with YmlTestFixtures2 {
+  "Config Reader" should {
+    "return a Map of all environments with missing env_var keys" in {
+      val expectedMissingKeys = Map(
+        "dev" -> Set("only_prod", "only_test"),
+        "prod" -> Set("only_dev", "only_test"),
+        "test" -> Set("only_dev", "only_prod", "dev_and_prod"))
+      val parsed = YamlParser.parse(YamlExampleWithMissingEnvVars, InfoLogger).asInstanceOf[ValidYaml]
+      val missingEnvVarKeys = ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
+      missingEnvVarKeys should be equalTo expectedMissingKeys
+    }
+
+    "return an empty map when there are no missing env_var keys" in {
+      val parsed = YamlParser.parse(YamlExampleWithValidEnvVars, InfoLogger).asInstanceOf[ValidYaml]
+      val missingEnvVarKeys = ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
+      missingEnvVarKeys should be equalTo Map()
+    }
+  }
+
+}
+
+trait YmlTestFixtures2 {
+  def YamlExampleWithMissingEnvVars = Source.fromURL(getClass.getResource("/config/example-config-with-missing-feature-toggles.yml")).mkString
+
+  def YamlExampleWithValidEnvVars = Source.fromURL(getClass.getResource("/config/example-config-with-feature-toggles-for-one-environment.yml")).mkString
+}


### PR DESCRIPTION
This PR should address the content of issue #44. It adds a function that checks if all the feature_toggles are set in each environment and returns a `Map[EnvironmentName, Set[String]]` for all the missing keys. 
This is used to print a warning to the console if the Map is not empty.

cc (@relistan, @sbz)