### PR TITLE
Add possibility to pass allowedSlaveAttributes

### DIFF
--- a/shared/src/main/scala/com/nitro/nmesos/commands/BaseCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/BaseCommand.scala
@@ -104,7 +104,7 @@ trait BaseCommand extends Command {
       case None =>
         Failure(new Exception(s" No Mesos config found with id: '${local.id}'"))
 
-      case Some(SingularityRequest(_, _, "SPREAD_ALL_SLAVES", _, _, _, _)) =>
+      case Some(SingularityRequest(_, _, "SPREAD_ALL_SLAVES", _, _, _, _, _)) =>
         Failure(new Exception(s" Unable to scale to a fix number of instances. Using auto-scale [slavePlacement: SPREAD_ALL_SLAVES]"))
 
       case Some(remote) if (remote.instances != local.instances) =>

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -46,7 +46,7 @@ object YamlParserHelper {
 
     implicit val resourcesFormat = yamlFormat3(Resources)
     implicit val containerFormat = yamlFormat9(Container)
-    implicit val singularityFormat = yamlFormat15(SingularityConf)
+    implicit val singularityFormat = yamlFormat16(SingularityConf)
     implicit val executorFormat = yamlFormat2(ExecutorConf)
     implicit val deployJobFormat = yamlFormat2(DeployJob)
     implicit val afterDeployFormat = yamlFormat2(AfterDeployConf)

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -66,6 +66,7 @@ object model {
     healthcheckMaxTotalTimeoutSeconds: Option[Int],
     requiredRole: Option[String],
     requiredAttributes: Option[Map[String, String]],
+    allowedSlaveAttributes: Option[Map[String, String]],
     slavePlacement: Option[String])
 
   case class ExecutorConf(

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
@@ -150,6 +150,7 @@ object ModelConversions {
     slavePlacement = config.environment.singularity.slavePlacement.getOrElse("OPTIMISTIC"),
     schedule = config.environment.singularity.schedule,
     requiredSlaveAttributes = config.environment.singularity.requiredAttributes.getOrElse(Map.empty),
+    allowedSlaveAttributes = config.environment.singularity.allowedSlaveAttributes.getOrElse(Map.empty),
     requiredRole = config.environment.singularity.requiredRole)
 
   def describeDeploy(request: SingularityRequest, deploy: SingularityDeploy): Seq[String] = {
@@ -161,7 +162,8 @@ object ModelConversions {
          | cpus: ${deploy.resources.cpus}
          | memory: ${deploy.resources.memoryMb}Mb
          | role: ${request.requiredRole.getOrElse("*")}
-         | attributes: ${request.requiredSlaveAttributes.mkString(",")}
+         | required slave attributes: ${request.requiredSlaveAttributes.mkString(",")}
+         | allowed slave attributes: ${request.allowedSlaveAttributes.mkString(",")}
          |""".stripMargin)
     if (request.schedule.isDefined) {
       common ++ request.schedule.map(cron => s"scheduled: $cron").toSeq

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/model.scala
@@ -72,6 +72,7 @@ object model {
     instances: Option[Int] = None,
     schedule: Option[String] = None,
     requiredSlaveAttributes: Map[String, String] = Map.empty,
+    allowedSlaveAttributes: Map[String, String] = Map.empty,
     requiredRole: Option[String] = None)
 
   case class SingularityDeployRequest(

--- a/shared/src/test/resources/config/example-mesos-attribute-config.yml
+++ b/shared/src/test/resources/config/example-mesos-attribute-config.yml
@@ -13,6 +13,8 @@ common:
     requiredAttributes: # Deploy only in nodes with the attributes
       mesosfunction: "master-prod"
       Role: "docker-host"
+    allowedSlaveAttributes:
+      compute_class: "high_cpu"
 
 environments:
   dev:

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -55,9 +55,14 @@ class YmlSpec extends Specification with YmlTestFixtures {
       modelConfig.environments("dev").singularity.slavePlacement should be equalTo Some("SPREAD_ALL_SLAVES")
     }
 
-    "parse the mesos slaves attributes in a valid Yaml file" in {
+    "parse the mesos slaves required and allowed attributes in a valid Yaml file" in {
       val conf = YamlParser.parse(YamlMesosAttributeConfig, InfoLogger)
       conf should beAnInstanceOf[ValidYaml]
+      val singularity = conf.asInstanceOf[ValidYaml].config.environments("dev").singularity
+      singularity.requiredAttributes shouldEqual Some(Map(
+        "mesosfunction" -> "master-prod",
+        "Role" -> "docker-host"))
+      singularity.allowedSlaveAttributes shouldEqual Some(Map("compute_class" -> "high_cpu"))
     }
 
     "parse the port config from a valid Yaml file" in {


### PR DESCRIPTION
Hello @felixgborrego and @sbz!

With this PR we wanted to add the possibility to pass `allowedSlaveAttributes` to the Singularity Request. 

Quite recently we not only needed the ability to pin certain requests to certain nodes, but also reserve these specific nodes for the mentioned requests only, done via `reserveSlaveWithAttributes ` in Singularity.
While this works for requests that have `requiredAttributes` set, we also have requests that need to run on every mesos node, also on these reserved nodes. To make some requests run on every mesos node, done via `SPREAD_ALL_SLAVES`, we need the ability to pass `allowedSlaveAttributes`.

I've added this to the test case and hope you're fine with this change.

Best regards,
Tom

cc @relistan 