### PR TITLE
Allow/support services that are not managed through mesos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# metals specific
+.metals/
+.bloop/
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name in ThisBuild := "nmesos"
 organization in ThisBuild := "com.gonitro"
-version in ThisBuild := "0.2.16"
-scalaVersion in ThisBuild := "2.12.1"
+version in ThisBuild := "0.2.17"
+scalaVersion in ThisBuild := "2.12.10"
 
 lazy val cli = Project("nmesos-cli", file("cli"))
   .dependsOn(shared)
@@ -14,7 +14,7 @@ lazy val shared = Project("nmesos-shared", file("shared"))
   .settings(Defaults.itSettings: _*)
   .settings(
     buildInfoPackage := "com.nitro.nmesos",
-    crossScalaVersions := Seq("2.12.1", "2.10.6"),
+    crossScalaVersions := Seq("2.12.10", "2.12.1", "2.10.6"),
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
       "net.jcazevedo" %% "moultingyaml" % "0.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,13 @@ organization in ThisBuild := "com.gonitro"
 version in ThisBuild := "0.2.17"
 scalaVersion in ThisBuild := "2.12.10"
 
+scalacOptions in ThisBuild ++= Seq(
+  "-unchecked",
+  "-deprecation",
+  "-feature",
+  "-Xfatal-warnings"
+)
+
 lazy val cli = Project("nmesos-cli", file("cli"))
   .dependsOn(shared)
   .configs(IntegrationTest)
@@ -22,7 +29,6 @@ lazy val shared = Project("nmesos-shared", file("shared"))
       "org.scalaj" %% "scalaj-http" % "2.3.0",
       "org.specs2" %% "specs2-core" % "3.8.6" % "it,test"
     ))
-
 
 lazy val root =
   project.in(file("."))

--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -17,8 +17,6 @@ mainClass in assembly := Some("com.nitro.nmesos.cli.Main")
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(cli))
 assemblyJarName in assembly := "nmesos"
 
-
-
 enablePlugins(UniversalPlugin)
 packageName in Universal := "nmesos-cli-" + version.value
 mappings in Universal in packageZipTarball := {

--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -1,6 +1,6 @@
 // Assembly as a CLI auto runnable bin.
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.10"
 organization := "nitro"
 
 libraryDependencies ++= Seq(

--- a/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
@@ -64,7 +64,7 @@ object CliParser {
           .abbr("t")
           .text("Tag/Version to release")
           .required()
-          .validate(tag => if (tag.isEmpty) Left("Tag is required") else Right())
+          .validate(tag => if (tag.isEmpty) Left("Tag is required") else Right(()))
           .action((input, params) => params.copy(tag = input)),
 
         opt[Unit]("force")

--- a/cli/src/test/scala/CliSpec.scala
+++ b/cli/src/test/scala/CliSpec.scala
@@ -158,6 +158,5 @@ trait CliSpecFixtures {
       case _ => None
     }
     config.getOrElse(sys.error("Invalid yml"))
-
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.3.7

--- a/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
@@ -63,11 +63,11 @@ object Validations extends ValidationHelper {
     })
 
   def isService(env: Environment) = {
-    (env.singularity.requestType.isEmpty && env.singularity.schedule.isEmpty) || env.singularity.requestType == "SERVICE"
+    (env.singularity.requestType.isEmpty && env.singularity.schedule.isEmpty) || env.singularity.requestType == Option("SERVICE")
   }
 
   def isScheduled(env: Environment) = {
-    (env.singularity.requestType.isEmpty && env.singularity.schedule.isDefined) || env.singularity.requestType == "SCHEDULED"
+    (env.singularity.requestType.isEmpty && env.singularity.schedule.isDefined) || env.singularity.requestType == Option("SCHEDULED")
   }
 }
 

--- a/shared/src/main/scala/com/nitro/nmesos/docker/SshDockerClient.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/docker/SshDockerClient.scala
@@ -2,6 +2,8 @@ package com.nitro.nmesos.docker
 
 import com.nitro.nmesos.docker.model.Container
 
+import scala.language.postfixOps
+
 import sys.process._
 
 /**

--- a/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarUtils.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarUtils.scala
@@ -53,8 +53,7 @@ object SidecarUtils {
   }
 
   def diffInfo(containerInfo: Seq[String], sidecarInfo: Seq[String], serviceName: String)(implicit log: Logger): Boolean = {
-    val diff = sidecarInfo.diff(containerInfo)
-    if (diff.isEmpty) {
+    if (containerInfo.sameElements(sidecarInfo)) {
       log.println(s""" ${log.Ok} Sidecar mapping for $serviceName match all containers running """)
       sidecarInfo.foreach { info =>
         log.info(s"\t\t$info")

--- a/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
@@ -9,10 +9,14 @@ class SidecarUtilsSpec extends Specification {
 
   "Sidecar Utils" should {
     "diff the infos right" in {
-      SidecarUtils.diffInfo(Seq("image @ host"), Seq("image @ host"), "service") should beTrue
-      SidecarUtils.diffInfo(Seq(), Seq("image @ host"), "service") should beTrue
-      SidecarUtils.diffInfo(Seq("image @ host"), Seq("image @ host", "image @ host2"), "service") should beFalse
-      SidecarUtils.diffInfo(Seq("image @ host", "image @ host2)"), Seq("image @ host"), "service") should beTrue
+      val containerNotDepoyedOnMesos = Seq()
+      val goodContainerInfo, goodSidecarInfo = Seq("image @ host")
+      val badContainerInfo, badSidecarInfo = Seq("image @ host", "image @ host2")
+
+      SidecarUtils.diffInfo(goodContainerInfo, goodSidecarInfo, "service") should beTrue
+      SidecarUtils.diffInfo(containerNotDepoyedOnMesos, goodSidecarInfo, "service") should beTrue
+      SidecarUtils.diffInfo(goodContainerInfo, badSidecarInfo, "service") should beFalse
+      SidecarUtils.diffInfo(badContainerInfo, goodSidecarInfo, "service") should beFalse
     }
   }
 }

--- a/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
@@ -1,0 +1,18 @@
+package com.nitro.nmesos.sidecar
+
+import org.specs2.mutable.Specification
+import com.nitro.nmesos.util.{ Logger, CustomLogger }
+
+class SidecarUtilsSpec extends Specification {
+
+  implicit val log = CustomLogger(ansiEnabled = true, verbose = true)
+
+  "Sidecar Utils" should {
+    "diff the infos right" in {
+      SidecarUtils.diffInfo(Seq("image @ host"), Seq("image @ host"), "service") should beTrue
+      SidecarUtils.diffInfo(Seq(), Seq("image @ host"), "service") should beTrue
+      SidecarUtils.diffInfo(Seq("image @ host"), Seq("image @ host", "image @ host2"), "service") should beFalse
+      SidecarUtils.diffInfo(Seq("image @ host", "image @ host2)"), Seq("image @ host"), "service") should beTrue
+    }
+  }
+}


### PR DESCRIPTION
## What/Why

This PR is to change the behavior of `verify` to support/allow services that are not managed by mesos.

The old behavior was to fail, if the service was known to sideca, but now known to mesos.

The new behavior is to just show an info that `verify` detected/found a service that is in sidecar, but not deployed/managed through mesos (e.g. that is deployed/managed directly with/through ansible).

This will make `verify` more useful in heterogenous deployment environments.

Futhermore this PR ...

* Upgrades nmesos to sbt 1.3.7/scala 2.12.10 (to support metals)
* Fixes all warnings 
