### PR TITLE
BugFix: Covering edge case where common config is empty.

### DIFF
--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -82,11 +82,6 @@ object YamlParserHelper {
     val common = yaml.fields(commonKey).asYamlObject
     val environments: Map[YamlValue, YamlValue] = yaml.fields(YamlString("environments")).asYamlObject.fields
 
-    var mergedFields = Map.empty[YamlValue, YamlValue]
-
-    // Add commons fields
-    mergedFields ++= common.fields
-
     // Add environments fields recursively
     val updatedEnvironments = environments.mapValues { environment =>
       smartMerge(common.fields, environment.asYamlObject)
@@ -100,7 +95,7 @@ object YamlParserHelper {
   private def smartMerge(initialFields: Map[YamlValue, YamlValue], element: YamlObject): YamlObject = {
     val fields = element.fields.foldLeft(initialFields) {
       case (mergedFields, (key, value)) =>
-        if (!mergedFields.contains(key)) {
+        if (!mergedFields.contains(key) || mergedFields(key) == YamlNull) {
           mergedFields + (key -> value)
         } else {
           // already exist, deep merge the objects.

--- a/shared/src/test/resources/config/example-without-optional-envvar-config.yml
+++ b/shared/src/test/resources/config/example-without-optional-envvar-config.yml
@@ -1,0 +1,31 @@
+## Example config for testing
+nmesos_version: '0.0.1' ## Min nmesos required to execute this config
+
+common:
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.1
+    memoryMb: 64
+
+  container:
+    image: busybox:latest
+    command: "echo test" ## pending
+    labels:
+      SidecarDiscover: "false"
+    env_vars:
+
+  singularity:
+    #numRetriesOnFailure: 2   # default is 0
+    schedule: "*/5 * * * *"
+    # optional deployInstanceCountPerStep: 1   # Number of instances deployed at once.
+    # optional autoAdvanceDeploySteps: true    # false to have Canary deployments.
+    # optional deployStepWaitTimeMs: 1000      # Time to wait between deployments
+    # optional healthcheckUri: "/hello"  # Used for singularity to determine if a deploy was success
+
+environments:
+  dev:
+    singularity:
+      url: "http://192.168.99.100:7099/singularity"
+    container:
+      env_vars:
+        NEW_RELIC_LICENSE_KEY: "xxxxx"

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -39,6 +39,10 @@ class YmlSpec extends Specification with YmlTestFixtures {
       YamlParser.parse(YamlJobExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
     }
 
+    "return a valid config from a valid Yaml with optional envar config being empty" in {
+      YamlParser.parse(YamlEnvVarExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
+    }
+
     "parse the executor configuration in a valid Yaml file" in {
       val conf = YamlParser.parse(YamlExampleExecutorEnvs, InfoLogger)
       conf should beAnInstanceOf[ValidYaml]
@@ -178,4 +182,6 @@ trait YmlTestFixtures {
   def YamlExampleWithDeployFreeze = Source.fromURL(getClass.getResource("/config/example-config-deploy-freeze.yml")).mkString
 
   def YamlExampleWithoutDeployFreeze = Source.fromURL(getClass.getResource("/config/example-config.yml")).mkString
+
+  def YamlEnvVarExampleValid = Source.fromURL(getClass.getResource("/config/example-without-optional-envvar-config.yml")).mkString
 }


### PR DESCRIPTION
## What/Why?

* Fixing a small bug, where we were not able to parse the yaml file, when a YamlObject was defined in `common`, but was empty/YamlNull