### PR TITLE
Remove 'curl' from url to get the brew command working

### DIFF
--- a/Formula/nmesos-cli.rb
+++ b/Formula/nmesos-cli.rb
@@ -3,7 +3,7 @@ require 'formula'
 class NmesosCli < Formula
   desc "Nmesos is a CLI tool to deploy into Mesos."
   homepage "https://github.com/Nitro/nmesos"
-  url "curl https://nmesos-releases.s3-eu-west-1.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.2.19/nmesos-cli-0.2.19.tgz"
+  url "https://nmesos-releases.s3-eu-west-1.amazonaws.com/nitro-public/repo/nitro/nmesos-cli/0.2.19/nmesos-cli-0.2.19.tgz"
   sha256 "6d2403cd27099ee2baf0578a6ae5e03c267a77c109d5ae1a8cfab479c8a5c7d4"
 
   option "with-bash-completion", "Install bash-completion"


### PR DESCRIPTION
Didn't see that there was an artifact hanging around there. Needed to remove `curl` from url. 