### PR TITLE
Feature: Run local via `docker run`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,10 +28,12 @@ lazy val shared = Project("nmesos-shared", file("shared"))
       "com.lihaoyi" %% "upickle" % "0.4.4",
       "org.scalaj" %% "scalaj-http" % "2.3.0",
       "org.specs2" %% "specs2-core" % "3.8.6" % "it,test"
-    ))
+    )
+  )
 
 lazy val root =
-  project.in(file("."))
+  project
+    .in(file("."))
     .dependsOn(cli)
 
 import scala.sys.process._

--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -12,7 +12,8 @@ val cli = Seq[String](
 )
 
 mainClass in assembly := Some("com.nitro.nmesos.cli.Main")
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(cli))
+assemblyOption in assembly := (assemblyOption in assembly).value
+  .copy(prependShellScript = Some(cli))
 assemblyJarName in assembly := "nmesos"
 
 enablePlugins(UniversalPlugin)
@@ -20,7 +21,9 @@ packageName in Universal := "nmesos-cli-" + version.value
 mappings in Universal in packageZipTarball := {
   Seq(
     file("README.md") -> "README.md",
-    file("contrib/etc/bash_completion.d/nmesos") -> "contrib/etc/bash_completion.d/nmesos",
+    file(
+      "contrib/etc/bash_completion.d/nmesos"
+    ) -> "contrib/etc/bash_completion.d/nmesos",
     file((assemblyOutputPath in assembly).value.getPath) -> "nmesos"
   )
 }
@@ -29,4 +32,6 @@ import com.typesafe.sbt.packager.SettingsHelper._
 makeDeploymentSettings(Universal, packageZipTarball, "tgz")
 
 awsProfile := Some("nmesos")
-publishTo := Some(s3resolver.value("nmesos-releases", s3("nmesos-releases/nitro-public/repo")))
+publishTo := Some(
+  s3resolver.value("nmesos-releases", s3("nmesos-releases/nitro-public/repo"))
+)

--- a/cli/src/it/scala/DeployChainIntegrationTest.scala
+++ b/cli/src/it/scala/DeployChainIntegrationTest.scala
@@ -2,7 +2,7 @@ package com.nitro.nmesos.cli
 
 import java.io.File
 
-import com.nitro.nmesos.cli.model.{ Cmd, ReleaseAction }
+import com.nitro.nmesos.cli.model.{Cmd, ReleaseAction}
 import com.nitro.nmesos.commands.ReleaseCommand
 import com.nitro.nmesos.config.ConfigReader
 import com.nitro.nmesos.config.ConfigReader.ValidConfig
@@ -17,15 +17,18 @@ import org.specs2.mutable.Specification
   * docker-compose rm
   * docker-compose up
   */
-class DeployChainIntegrationTest extends Specification with DeployChainFixtures {
+class DeployChainIntegrationTest
+    extends Specification
+    with DeployChainFixtures {
 
   // dirty hack so that the test doesn't scream the
   // "No implicits found for parameter evidence"
   // because the last line is not an assertion
   import org.specs2.execute._
-  implicit def unitAsResult: AsResult[Unit] = new AsResult[Unit] {
-    def asResult(u: => Unit): Result = { u; Success() }
-  }
+  implicit def unitAsResult: AsResult[Unit] =
+    new AsResult[Unit] {
+      def asResult(u: => Unit): Result = { u; Success() }
+    }
 
   "Cli main" should {
 
@@ -39,9 +42,11 @@ class DeployChainIntegrationTest extends Specification with DeployChainFixtures 
 
       // First file to deploy that has a deploy-chain on it
       val cmd = ValidCmd.copy(
-        serviceName = "cli/src/it/resources/config/example-deploy-chain-service-real-0",
+        serviceName =
+          "cli/src/it/resources/config/example-deploy-chain-service-real-0",
         tag = "stable",
-        isDryrun = false)
+        isDryrun = false
+      )
 
       // Kickoff
       CliManager.processCmd(cmd)
@@ -51,16 +56,24 @@ class DeployChainIntegrationTest extends Specification with DeployChainFixtures 
       val runningTasks = manager.getSingularityActiveTasks().get
       for (runningTask <- runningTasks) {
         (expectedDeployedServices contains runningTask.taskId.requestId) shouldEqual true
-        if (runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_0") {
+        if (
+          runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_0"
+        ) {
           runningTask.taskId.deployId.contains("stable").shouldEqual(true)
         }
-        if (runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_1") {
+        if (
+          runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_1"
+        ) {
           runningTask.taskId.deployId.contains("stable").shouldEqual(true)
         }
-        if (runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_2") {
+        if (
+          runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_2"
+        ) {
           runningTask.taskId.deployId.contains("alpine").shouldEqual(true)
         }
-        if (runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_3") {
+        if (
+          runningTask.taskId.requestId == "dev_example_deploy_chain_service_real_3"
+        ) {
           runningTask.taskId.deployId.contains("mainline").shouldEqual(true)
         }
       }
@@ -87,12 +100,23 @@ trait DeployChainFixtures {
 
   def getManager(serviceName: String) = {
     val serviceNameWithPath = s"cli/src/it/resources/config/${serviceName}"
-    val yamlFile = new File(getClass.getResource(s"/config/${serviceName}.yml").toURI)
-    val cmdConfig = ConfigReader.parseEnvironment(yamlFile, "dev", InfoLogger) match {
-      case validConfig: ValidConfig =>
-        CmdConfig(serviceNameWithPath, "latest", force = false, validConfig.environmentName, validConfig.environment, validConfig.fileHash, yamlFile)
-      case other => sys.error(other.toString)
-    }
+    val yamlFile = new File(
+      getClass.getResource(s"/config/${serviceName}.yml").toURI
+    )
+    val cmdConfig =
+      ConfigReader.parseEnvironment(yamlFile, "dev", InfoLogger) match {
+        case validConfig: ValidConfig =>
+          CmdConfig(
+            serviceNameWithPath,
+            "latest",
+            force = false,
+            validConfig.environmentName,
+            validConfig.environment,
+            validConfig.fileHash,
+            yamlFile
+          )
+        case other => sys.error(other.toString)
+      }
 
     ReleaseCommand(
       cmdConfig,

--- a/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
@@ -197,6 +197,28 @@ object CliParser {
           .action((input, params) => params.copy(singularity = input))
       )
 
+    note("\n")
+
+    cmd("run-local")
+      .text("Run the service locally with environment variables from dev")
+      .required()
+      .action((_, params) => params.copy(action = RunLocalAction))
+      .children(
+        arg[String]("service-name")
+          .text("Name of the service to release")
+          .required()
+          .action((input, params) => params.copy(serviceName = input)),
+        opt[String]("tag")
+          .abbr("t")
+          .text("Tag/Version to release")
+          .required()
+          .validate(tag =>
+            if (tag.isEmpty) Left("Tag is required")
+            else Right(())
+          )
+          .action((input, params) => params.copy(tag = input))
+      )
+
     checkConfig { cmd =>
       val availableCommands = commands.map(_.fullName).mkString("|")
       if (cmd.action != NilAction) success

--- a/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
@@ -4,17 +4,17 @@ import com.nitro.nmesos.cli.model._
 import com.nitro.nmesos.BuildInfo
 
 /**
- * CLI parser from `args` to `Cmd`.
- * Usage:
- *  val cmds = Cli.parser(args)
- * Cli example:
- *  nmesos release service_name \
- *    --environment dev \
- *    --version 0.0.1 \
- *    --dry-run false \
- *    --deprecated-soft-grace-period 10 \
- *    --deprecated-hard-grace-period 20
- */
+  * CLI parser from `args` to `Cmd`.
+  * Usage:
+  *  val cmds = Cli.parser(args)
+  * Cli example:
+  *  nmesos release service_name \
+  *    --environment dev \
+  *    --version 0.0.1 \
+  *    --dry-run false \
+  *    --deprecated-soft-grace-period 10 \
+  *    --deprecated-hard-grace-period 20
+  */
 object CliParser {
 
   def parse(args: Array[String]): Option[Cmd] = {
@@ -29,7 +29,8 @@ object CliParser {
       tag = "",
       force = false,
       deprecatedSoftGracePeriod = DefaultValues.DeprecatedSoftGracePeriod,
-      deprecatedHardGracePeriod = DefaultValues.DeprecatedHardGracePeriod)
+      deprecatedHardGracePeriod = DefaultValues.DeprecatedHardGracePeriod
+    )
     cmdParser.parse(args, nilCommand)
   }
 
@@ -53,125 +54,139 @@ object CliParser {
     note("\n")
 
     cmd("release")
-      .text("Release the a new version of the service.\n Usage:  nmesos release example-service --environment dev --tag 0.0.1")
+      .text(
+        "Release the a new version of the service.\n Usage:  nmesos release example-service --environment dev --tag 0.0.1"
+      )
       .required()
       .action((_, params) => params.copy(action = ReleaseAction))
       .children(
-
         arg[String]("service-name")
           .text("Name of the service to release")
           .required()
           .action((input, params) => params.copy(serviceName = input)),
-
         opt[String]("environment")
           .abbr("e")
           .text("The environment to use")
           .required()
           .action((input, params) => params.copy(environment = input)),
-
         opt[String]("tag")
           .abbr("t")
           .text("Tag/Version to release")
           .required()
-          .validate(tag => if (tag.isEmpty) Left("Tag is required") else Right(()))
+          .validate(tag =>
+            if (tag.isEmpty) Left("Tag is required")
+            else Right(())
+          )
           .action((input, params) => params.copy(tag = input)),
-
         opt[Unit]("force")
           .abbr("f")
           .text("Force action!!!}")
           .optional()
           .action((input, params) => params.copy(force = true)),
-
         opt[Boolean]("dryrun")
           .abbr("x")
           .text("Deprecated. Will be removed soon.")
           .optional()
           .action((input, params) => params.copy(isDryrun = input)),
-
         opt[Boolean]("dry-run")
           .abbr("n")
           .text(s"Is this a dry run? Default: ${DefaultValues.IsDryRun}")
           .optional()
           .action((input, params) => params.copy(isDryrun = input)),
-
         opt[Int]("deprecated-soft-grace-period")
           .abbr("S")
-          .text(s"Number of days, before warning. Default: ${DefaultValues.DeprecatedSoftGracePeriod}")
+          .text(
+            s"Number of days, before warning. Default: ${DefaultValues.DeprecatedSoftGracePeriod}"
+          )
           .optional()
-          .action((input, params) => params.copy(deprecatedSoftGracePeriod = input)),
-
+          .action((input, params) =>
+            params.copy(deprecatedSoftGracePeriod = input)
+          ),
         opt[Int]("deprecated-hard-grace-period")
           .abbr("H")
-          .text(s"Number of days, before error/abort. Default: ${DefaultValues.DeprecatedHardGracePeriod}")
+          .text(
+            s"Number of days, before error/abort. Default: ${DefaultValues.DeprecatedHardGracePeriod}"
+          )
           .optional()
-          .action((input, params) => params.copy(deprecatedHardGracePeriod = input)))
+          .action((input, params) =>
+            params.copy(deprecatedHardGracePeriod = input)
+          )
+      )
 
     note("\n")
 
     cmd("scale")
-      .text(" Update the Environment.\n Usage: nmesos scale service_name --environment dev")
+      .text(
+        " Update the Environment.\n Usage: nmesos scale service_name --environment dev"
+      )
       .required()
       .action((_, params) => params.copy(action = ScaleAction))
       .children(
-
         arg[String]("service-name")
           .text("Name of the service to scale")
           .required()
           .action((input, params) => params.copy(serviceName = input)),
-
         opt[String]("environment")
           .abbr("e")
           .text("The environment to use")
           .required()
           .action((input, params) => params.copy(environment = input)),
-
         opt[Boolean]("dryrun")
           .abbr("x")
           .text("Deprecated. Will be removed soon.")
           .optional()
           .action((input, params) => params.copy(isDryrun = input)),
-
         opt[Boolean]("dry-run")
           .abbr("n")
           .text(s"Is this a dry run? Default: ${DefaultValues.IsDryRun}")
           .optional()
-          .action((input, params) => params.copy(isDryrun = input)))
+          .action((input, params) => params.copy(isDryrun = input))
+      )
 
     note("\n")
 
     cmd("check")
-      .text(" Check the environment conf without running it.\n Usage: nmesos check service_name --environment dev")
+      .text(
+        " Check the environment conf without running it.\n Usage: nmesos check service_name --environment dev"
+      )
       .required()
       .action((_, params) => params.copy(action = CheckAction))
       .children(
-
         arg[String]("service-name")
           .text("Name of the service to verify")
           .required()
           .action((input, params) => params.copy(serviceName = input)),
-
         opt[String]("environment")
           .abbr("e")
           .text("The environment to verify")
           .required()
           .action((input, params) => params.copy(environment = input)),
-
         opt[Int]("deprecated-soft-grace-period")
           .abbr("S")
-          .text(s"Number of days, before warning. Default: ${DefaultValues.DeprecatedSoftGracePeriod}")
+          .text(
+            s"Number of days, before warning. Default: ${DefaultValues.DeprecatedSoftGracePeriod}"
+          )
           .optional()
-          .action((input, params) => params.copy(deprecatedSoftGracePeriod = input)),
-
+          .action((input, params) =>
+            params.copy(deprecatedSoftGracePeriod = input)
+          ),
         opt[Int]("deprecated-hard-grace-period")
           .abbr("H")
-          .text(s"Number of days, before error/abort. Default: ${DefaultValues.DeprecatedHardGracePeriod}")
+          .text(
+            s"Number of days, before error/abort. Default: ${DefaultValues.DeprecatedHardGracePeriod}"
+          )
           .optional()
-          .action((input, params) => params.copy(deprecatedHardGracePeriod = input)))
+          .action((input, params) =>
+            params.copy(deprecatedHardGracePeriod = input)
+          )
+      )
 
     note("\n")
 
     cmd("verify")
-      .text(" Verify a complete Singularity server by comparing the expected Singularity state with the Mesos state and docker state\n Usage: nmesos verify --singularity http://url/singularity")
+      .text(
+        " Verify a complete Singularity server by comparing the expected Singularity state with the Mesos state and docker state\n Usage: nmesos verify --singularity http://url/singularity"
+      )
       .required()
       .action((_, params) => params.copy(action = VerifyAction))
       .children(
@@ -179,11 +194,13 @@ object CliParser {
           .abbr("s")
           .text("The environment to verify")
           .required()
-          .action((input, params) => params.copy(singularity = input)))
+          .action((input, params) => params.copy(singularity = input))
+      )
 
     checkConfig { cmd =>
       val availableCommands = commands.map(_.fullName).mkString("|")
-      if (cmd.action != NilAction) success else failure(s"A command is required. $availableCommands\n")
+      if (cmd.action != NilAction) success
+      else failure(s"A command is required. $availableCommands\n")
     }
 
     override def showUsageOnError: Boolean = true

--- a/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/CliParser.scala
@@ -205,7 +205,7 @@ object CliParser {
       .action((_, params) => params.copy(action = RunLocalAction))
       .children(
         arg[String]("service-name")
-          .text("Name of the service to release")
+          .text("Name of the service to run")
           .required()
           .action((input, params) => params.copy(serviceName = input)),
         opt[String]("tag")

--- a/cli/src/main/scala/com/nitro/nmesos/cli/Main.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/Main.scala
@@ -232,9 +232,7 @@ object CliManager {
         RunLocalCommand(
           serviceConfig,
           log,
-          isDryrun = false,
-          deprecatedSoftGracePeriod = cmd.deprecatedSoftGracePeriod,
-          deprecatedHardGracePeriod = cmd.deprecatedHardGracePeriod
+          isDryrun = false
         ).run()
 
       case other =>

--- a/cli/src/main/scala/com/nitro/nmesos/cli/model.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/model.scala
@@ -33,5 +33,5 @@ object model {
   case object ScaleAction extends Action
   case object CheckAction extends Action
   case object VerifyAction extends Action
-
+  case object RunLocalAction extends Action
 }

--- a/cli/src/main/scala/com/nitro/nmesos/cli/model.scala
+++ b/cli/src/main/scala/com/nitro/nmesos/cli/model.scala
@@ -1,22 +1,23 @@
 package com.nitro.nmesos.cli
 
 /**
- * CLI input model
- */
+  * CLI input model
+  */
 object model {
 
   case class Cmd(
-    isDryrun: Boolean,
-    verbose: Boolean,
-    isFormatted: Boolean,
-    serviceName: String,
-    environment: String,
-    singularity: String,
-    tag: String,
-    force: Boolean,
-    action: Action,
-    deprecatedSoftGracePeriod: Int,
-    deprecatedHardGracePeriod: Int)
+      isDryrun: Boolean,
+      verbose: Boolean,
+      isFormatted: Boolean,
+      serviceName: String,
+      environment: String,
+      singularity: String,
+      tag: String,
+      force: Boolean,
+      action: Action,
+      deprecatedSoftGracePeriod: Int,
+      deprecatedHardGracePeriod: Int
+  )
 
   object DefaultValues {
     val IsDryRun = true

--- a/cli/src/test/scala/CliSpec.scala
+++ b/cli/src/test/scala/CliSpec.scala
@@ -11,6 +11,8 @@ import com.nitro.nmesos.singularity.ModelConversions.toSingularityRequest
 import com.nitro.nmesos.singularity.{RealSingularityManager, SingularityManager}
 import com.nitro.nmesos.util.InfoLogger
 import org.specs2.mutable.Specification
+import com.nitro.nmesos.cli.model.RunLocalAction
+import com.nitro.nmesos.cli.model.DefaultValues
 
 class CliSpec extends Specification with CliSpecFixtures {
 
@@ -145,6 +147,10 @@ class CliSpec extends Specification with CliSpecFixtures {
       val cmd = CliParser.parse(ValidCliArgsLong)
       cmd should be equalTo Some(ValidCmd)
     }
+    "parse a valid run-local command" in {
+      val cmd = CliParser.parse(ValidRunLocalCliArgs)
+      cmd should be equalTo Some(ValidRunLocalCmd)
+    }
 
     "fail to parse an invalid release command" in {
       val cmd = CliParser.parse(InvalidCliArgs)
@@ -164,6 +170,9 @@ trait CliSpecFixtures {
   val ValidCliArgsLong =
     "release testService --verbose --noformat --environment dev --tag latest --deprecated-soft-grace-period 10 --deprecated-hard-grace-period 20 --force --dry-run false"
       .split(" ")
+
+  val ValidRunLocalCliArgs = "run-local testService -t random-tag".split(" ")
+
   val InvalidCliArgs = "release test -e dev -t".split(" ")
 
   val ValidCmd = Cmd(
@@ -178,6 +187,20 @@ trait CliSpecFixtures {
     force = true,
     deprecatedSoftGracePeriod = 10,
     deprecatedHardGracePeriod = 20
+  )
+
+  val ValidRunLocalCmd = Cmd(
+    action = RunLocalAction,
+    isDryrun = DefaultValues.IsDryRun,
+    verbose = DefaultValues.Verbose,
+    isFormatted = DefaultValues.IsFormatted,
+    serviceName = "testService",
+    environment = "",
+    singularity = "",
+    tag = "random-tag",
+    force = false,
+    deprecatedSoftGracePeriod = DefaultValues.DeprecatedSoftGracePeriod,
+    deprecatedHardGracePeriod = DefaultValues.DeprecatedHardGracePeriod
   )
 
   lazy val ValidYamlConfig = {

--- a/cli/src/test/scala/CliSpec.scala
+++ b/cli/src/test/scala/CliSpec.scala
@@ -2,13 +2,13 @@ package com.nitro.nmesos.cli
 
 import java.io.File
 
-import com.nitro.nmesos.cli.model.{ Cmd, ReleaseAction }
+import com.nitro.nmesos.cli.model.{Cmd, ReleaseAction}
 import com.nitro.nmesos.commands.ReleaseCommand
 import com.nitro.nmesos.config.ConfigReader
 import com.nitro.nmesos.config.ConfigReader.ValidConfig
 import com.nitro.nmesos.config.model.CmdConfig
 import com.nitro.nmesos.singularity.ModelConversions.toSingularityRequest
-import com.nitro.nmesos.singularity.{ RealSingularityManager, SingularityManager }
+import com.nitro.nmesos.singularity.{RealSingularityManager, SingularityManager}
 import com.nitro.nmesos.util.InfoLogger
 import org.specs2.mutable.Specification
 
@@ -27,7 +27,8 @@ class CliSpec extends Specification with CliSpecFixtures {
       val cmd = ValidCmd.copy(
         serviceName =
           "cli/src/test/resources/config/example-deploy-chain-service-0",
-        tag = "specialTag")
+        tag = "specialTag"
+      )
 
       val expectedCommandChainOnSuccess =
         List(
@@ -37,30 +38,39 @@ class CliSpec extends Specification with CliSpecFixtures {
               serviceName =
                 "cli/src/test/resources/config/example-deploy-chain-service-1",
               tag = "job1tag",
-              force = true),
-              getValidYmlConfig("example-deploy-chain-service-1")),
+              force = true
+            ),
+            getValidYmlConfig("example-deploy-chain-service-1")
+          ),
           (
             cmd.copy(
               serviceName =
                 "cli/src/test/resources/config/example-deploy-chain-service-2",
               tag = "specialTag",
-              force = true),
-              getValidYmlConfig("example-deploy-chain-service-2")),
+              force = true
+            ),
+            getValidYmlConfig("example-deploy-chain-service-2")
+          ),
           (
             cmd.copy(
               serviceName =
                 "cli/src/test/resources/config/example-deploy-chain-service-3",
               tag = "job3tag",
-              force = true),
-              getValidYmlConfig("example-deploy-chain-service-3")))
+              force = true
+            ),
+            getValidYmlConfig("example-deploy-chain-service-3")
+          )
+        )
 
       val expectedCommandOnFailure = (
         cmd.copy(
           serviceName =
             "cli/src/test/resources/config/example-deploy-chain-failure",
           tag = "jobFailureTag",
-          force = true),
-          getValidYmlConfig("example-deploy-chain-failure"))
+          force = true
+        ),
+        getValidYmlConfig("example-deploy-chain-failure")
+      )
 
       val (commandChainOnSuccess, commandOnFailure) =
         CliManager.getCommandChain(cmd, InfoLogger).right.get
@@ -83,7 +93,8 @@ class CliSpec extends Specification with CliSpecFixtures {
       val cmd = ValidCmd.copy(
         serviceName =
           "cli/src/test/resources/config/example-deploy-chain-service-2",
-        tag = "latest")
+        tag = "latest"
+      )
       val (commandChainOnSuccess, commandOnFailure) =
         CliManager.getCommandChain(cmd, InfoLogger).right.get
 
@@ -91,8 +102,10 @@ class CliSpec extends Specification with CliSpecFixtures {
         cmd.copy(
           serviceName =
             "cli/src/test/resources/config/example-deploy-chain-service-2",
-          tag = "latest"),
-          getValidYmlConfig("example-deploy-chain-service-2"))
+          tag = "latest"
+        ),
+        getValidYmlConfig("example-deploy-chain-service-2")
+      )
 
       commandChainOnSuccess.length shouldEqual 1
 
@@ -104,7 +117,8 @@ class CliSpec extends Specification with CliSpecFixtures {
 
     "return an error on a cyclic reference command chain" in {
       val cmd = ValidCmd.copy(serviceName =
-        "cli/src/test/resources/config/example-deploy-chain-service-cyclic-0")
+        "cli/src/test/resources/config/example-deploy-chain-service-cyclic-0"
+      )
       val commandChain = CliManager.getCommandChain(cmd, InfoLogger)
 
       commandChain.left.get.msg shouldEqual "Job appearing more than once in job chain"
@@ -112,7 +126,8 @@ class CliSpec extends Specification with CliSpecFixtures {
 
     "return an error for a self referencing after deploy job" in {
       val cmd = ValidCmd.copy(serviceName =
-        "cli/src/test/resources/config/example-deploy-chain-self-referencing")
+        "cli/src/test/resources/config/example-deploy-chain-self-referencing"
+      )
       val commandChain = CliManager.getCommandChain(cmd, InfoLogger)
 
       commandChain.left.get.msg shouldEqual "Job appearing more than once in job chain"
@@ -142,8 +157,13 @@ class CliSpec extends Specification with CliSpecFixtures {
 
 trait CliSpecFixtures {
 
-  val ValidCliArgs = "release testService -v -d -e dev -t latest -S 10 -H 20 -f -n false".split(" ")
-  val ValidCliArgsLong = "release testService --verbose --noformat --environment dev --tag latest --deprecated-soft-grace-period 10 --deprecated-hard-grace-period 20 --force --dry-run false".split(" ")
+  val ValidCliArgs =
+    "release testService -v -d -e dev -t latest -S 10 -H 20 -f -n false".split(
+      " "
+    )
+  val ValidCliArgsLong =
+    "release testService --verbose --noformat --environment dev --tag latest --deprecated-soft-grace-period 10 --deprecated-hard-grace-period 20 --force --dry-run false"
+      .split(" ")
   val InvalidCliArgs = "release test -e dev -t".split(" ")
 
   val ValidCmd = Cmd(
@@ -157,24 +177,27 @@ trait CliSpecFixtures {
     tag = "latest",
     force = true,
     deprecatedSoftGracePeriod = 10,
-    deprecatedHardGracePeriod = 20)
+    deprecatedHardGracePeriod = 20
+  )
 
   lazy val ValidYamlConfig = {
     val yml = new File(
-      getClass.getResource("/config/example-config.yml").getFile)
+      getClass.getResource("/config/example-config.yml").getFile
+    )
     val config = ConfigReader.parseEnvironment(yml, "dev", InfoLogger) match {
       case v: ValidConfig => Some(v)
-      case _ => None
+      case _              => None
     }
     config.getOrElse(sys.error("Invalid yml"))
   }
 
   def getValidYmlConfig(serviceName: String): ValidConfig = {
     val yml = new File(
-      getClass.getResource(s"/config/${serviceName}.yml").getFile)
+      getClass.getResource(s"/config/${serviceName}.yml").getFile
+    )
     val config = ConfigReader.parseEnvironment(yml, "dev", InfoLogger) match {
       case v: ValidConfig => Some(v)
-      case _ => None
+      case _              => None
     }
     config.getOrElse(sys.error("Invalid yml"))
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")
 

--- a/sbt-plugin/example-project/project/plugins.sbt
+++ b/sbt-plugin/example-project/project/plugins.sbt
@@ -1,3 +1,2 @@
 // Add plugin to release to Mesos
 addSbtPlugin("com.gonitro" % "sbt-nmesos" % "0.0.8")
-

--- a/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/ArgumentsParser.scala
+++ b/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/ArgumentsParser.scala
@@ -1,15 +1,15 @@
 package com.nitro.nmesos.sbt.cli
 
 import com.nitro.nmesos.BuildInfo
-import com.nitro.nmesos.sbt.model.{ DefaultValues, ReleaseArgs }
+import com.nitro.nmesos.sbt.model.{DefaultValues, ReleaseArgs}
 
 /**
- * SBT args parser from `args` to `Cmd`.
- * Usage:
- * val cmds = ArgumentsParser.parser(args)
- * Cli example:
- * nmesosRelease service_name --environment dev --tag 0.0.1 --dry-run false
- */
+  * SBT args parser from `args` to `Cmd`.
+  * Usage:
+  * val cmds = ArgumentsParser.parser(args)
+  * Cli example:
+  * nmesosRelease service_name --environment dev --tag 0.0.1 --dry-run false
+  */
 object ArgumentsParser {
 
   def parseReleaseArgs(args: Seq[String]): Option[ReleaseArgs] = {

--- a/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/NmesosPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/NmesosPlugin.scala
@@ -7,15 +7,15 @@ import sbt._
 import sbt.complete.Parsers.spaceDelimited
 
 /**
- * Auto Sbt Plugin for NMesos.
- */
+  * Auto Sbt Plugin for NMesos.
+  */
 object NmesosPlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
   /**
-   * Public task and keys offered by the plugin.
-   */
+    * Public task and keys offered by the plugin.
+    */
   object autoImport {
 
     lazy val nmesosRepositoryConfig = taskKey[String](
@@ -34,32 +34,41 @@ object NmesosPlugin extends AutoPlugin {
   object defaults {
 
     /**
-     * Default value of nmesosRepositoryConfig = env var NMESOS_CONFIG_REPOSITORY
-     */
-    def nmesosRepositoryConfigKey = nmesosRepositoryConfig := {
-      val base = baseDirectory.value
-      val log = (streams in nmesosRelease).value.log
-      NmesosPluginImpl.resolveRepositoryPath(base, log)
-    }
-
-    def nmesosReleaseKey = nmesosRelease := {
-      val args = spaceDelimited(ArgumentsParser.releaseExampleUsage).parsed
-      ArgumentsParser.parseReleaseArgs(args) match {
-        case None =>
-          sys.error(s"Invalid args. ${ArgumentsParser.releaseExampleUsage}")
-
-        case Some(arguments) =>
-          val serviceName = name.value
-          val log = (streams in nmesosRelease).value.log
-          val repositoryConfigPath = file(nmesosRepositoryConfig.value)
-          val defaultVersion = sbt.Keys.version.value
-
-          NmesosPluginImpl.release(arguments, serviceName, repositoryConfigPath, defaultVersion, log)
-
+      * Default value of nmesosRepositoryConfig = env var NMESOS_CONFIG_REPOSITORY
+      */
+    def nmesosRepositoryConfigKey =
+      nmesosRepositoryConfig := {
+        val base = baseDirectory.value
+        val log = (streams in nmesosRelease).value.log
+        NmesosPluginImpl.resolveRepositoryPath(base, log)
       }
-    }
 
-    lazy val defaultSettings: Seq[Setting[_]] = Seq(nmesosReleaseKey, nmesosRepositoryConfigKey, nmesosReleaseKey)
+    def nmesosReleaseKey =
+      nmesosRelease := {
+        val args = spaceDelimited(ArgumentsParser.releaseExampleUsage).parsed
+        ArgumentsParser.parseReleaseArgs(args) match {
+          case None =>
+            sys.error(s"Invalid args. ${ArgumentsParser.releaseExampleUsage}")
+
+          case Some(arguments) =>
+            val serviceName = name.value
+            val log = (streams in nmesosRelease).value.log
+            val repositoryConfigPath = file(nmesosRepositoryConfig.value)
+            val defaultVersion = sbt.Keys.version.value
+
+            NmesosPluginImpl.release(
+              arguments,
+              serviceName,
+              repositoryConfigPath,
+              defaultVersion,
+              log
+            )
+
+        }
+      }
+
+    lazy val defaultSettings: Seq[Setting[_]] =
+      Seq(nmesosReleaseKey, nmesosRepositoryConfigKey, nmesosReleaseKey)
 
   }
 

--- a/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/NmesosPluginImpl.scala
+++ b/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/NmesosPluginImpl.scala
@@ -1,17 +1,17 @@
 package com.nitro.nmesos.sbt
 
-import com.nitro.nmesos.commands.{ CommandError, CommandSuccess, ReleaseCommand }
+import com.nitro.nmesos.commands.{CommandError, CommandSuccess, ReleaseCommand}
 import com.nitro.nmesos.config.ConfigReader
-import com.nitro.nmesos.config.ConfigReader.{ ConfigError, ValidConfig }
+import com.nitro.nmesos.config.ConfigReader.{ConfigError, ValidConfig}
 import com.nitro.nmesos.config.model.CmdConfig
 import com.nitro.nmesos.sbt.model.ReleaseArgs
-import com.nitro.nmesos.util.{ Logger => NLogger }
+import com.nitro.nmesos.util.{Logger => NLogger}
 import sbt._
 import sbt.Logger
 
 /**
- * Parse sbt args, read the configuration file and execute the command.
- */
+  * Parse sbt args, read the configuration file and execute the command.
+  */
 object NmesosPluginImpl {
 
   val ConfigRepositoryEnvName = "NMESOS_CONFIG_REPOSITORY"
@@ -21,7 +21,9 @@ object NmesosPluginImpl {
     val envValue = sys.env.get(ConfigRepositoryEnvName)
     val path = envValue match {
       case None =>
-        log.warn(s"[Nmesos] Environment var $ConfigRepositoryEnvName is not defined, using default path ${defaultPath.getAbsolutePath}")
+        log.warn(
+          s"[Nmesos] Environment var $ConfigRepositoryEnvName is not defined, using default path ${defaultPath.getAbsolutePath}"
+        )
         defaultPath.getAbsolutePath
       case Some(path) =>
         log.info(s"[Nmesos] Environment var $ConfigRepositoryEnvName=$path")
@@ -33,7 +35,13 @@ object NmesosPluginImpl {
     path
   }
 
-  def release(args: ReleaseArgs, serviceName: String, repositoryConfigPath: File, localVersion: String, logger: Logger) = {
+  def release(
+      args: ReleaseArgs,
+      serviceName: String,
+      repositoryConfigPath: File,
+      localVersion: String,
+      logger: Logger
+  ) = {
 
     val yamlFile = repositoryConfigPath / s"$serviceName.yml"
 
@@ -47,7 +55,9 @@ object NmesosPluginImpl {
           s""" Configuration Repo:          $repositoryConfigPath
              | Configuration service file:  $yamlFile
              | Local version:               ${log.infoColor(localVersion)}
-             | Version to deploy:           ${log.infoColor(args.tag)}""".stripMargin
+             | Version to deploy:           ${log.infoColor(
+            args.tag
+          )}""".stripMargin
         )
       }
 
@@ -56,16 +66,21 @@ object NmesosPluginImpl {
           showConfigError(serviceName, error, log)
 
         case config: ValidConfig =>
-
           executeCommand(args, serviceName, config, log)
       }
     }
 
   }
 
-  def executeCommand(args: ReleaseArgs, serviceName: String, config: ValidConfig, log: NLogger) = {
+  def executeCommand(
+      args: ReleaseArgs,
+      serviceName: String,
+      config: ValidConfig,
+      log: NLogger
+  ) = {
     val serviceConfig = toServiceConfig(serviceName, args, config)
-    val cmdResult = ReleaseCommand(serviceConfig, log, isDryrun = args.isDryrun).run()
+    val cmdResult =
+      ReleaseCommand(serviceConfig, log, isDryrun = args.isDryrun).run()
 
     cmdResult match {
       case CommandSuccess(msg) =>
@@ -77,10 +92,13 @@ object NmesosPluginImpl {
 
   }
 
-  def showConfigError(serviceName: String, configError: ConfigError, log: NLogger): Unit = {
+  def showConfigError(
+      serviceName: String,
+      configError: ConfigError,
+      log: NLogger
+  ): Unit = {
     log.logBlock("Invalid config") {
-      log.info(
-        s""" Service Name: $serviceName
+      log.info(s""" Service Name: $serviceName
            | Config File: ${configError.yamlFile.getAbsolutePath}
              """.stripMargin)
       log.error(configError.msg)
@@ -88,13 +106,19 @@ object NmesosPluginImpl {
     sys.error(configError.msg)
   }
 
-  def toServiceConfig(serviceName: String, cmd: ReleaseArgs, config: ValidConfig) = CmdConfig(
-    serviceName = serviceName,
-    force = cmd.force,
-    tag = cmd.tag,
-    environment = config.environment,
-    environmentName = config.environmentName,
-    fileHash = config.fileHash,
-    file = config.file)
+  def toServiceConfig(
+      serviceName: String,
+      cmd: ReleaseArgs,
+      config: ValidConfig
+  ) =
+    CmdConfig(
+      serviceName = serviceName,
+      force = cmd.force,
+      tag = cmd.tag,
+      environment = config.environment,
+      environmentName = config.environmentName,
+      fileHash = config.fileHash,
+      file = config.file
+    )
 
 }

--- a/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/SbtCustomLogger.scala
+++ b/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/SbtCustomLogger.scala
@@ -3,10 +3,11 @@ package com.nitro.nmesos.sbt
 import com.nitro.nmesos.util.Logger
 
 /**
- * Redirect logs to the standard sbt logger.
- */
+  * Redirect logs to the standard sbt logger.
+  */
 case class SbtCustomLogger(sbtLogger: sbt.Logger) extends Logger {
-  override def error(msg: => Any): Unit = sbtLogger.error(errorColor(msg).toString)
+  override def error(msg: => Any): Unit =
+    sbtLogger.error(errorColor(msg).toString)
   override def info(msg: => Any): Unit = sbtLogger.info(infoColor(msg).toString)
   override def println(msg: => Any): Unit = sbtLogger.info(msg.toString)
 

--- a/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/model.scala
+++ b/sbt-plugin/src/main/scala/com/nitro/nmesos/sbt/model.scala
@@ -1,18 +1,18 @@
 package com.nitro.nmesos.sbt
 
 /**
- * CLI Sbt input model
- */
+  * CLI Sbt input model
+  */
 object model {
 
   sealed trait SbtCommandArgs
 
   case class ReleaseArgs(
-    isDryrun: Boolean,
-    verbose: Boolean,
-    environment: String,
-    tag: String,
-    force: Boolean
+      isDryrun: Boolean,
+      verbose: Boolean,
+      environment: String,
+      tag: String,
+      force: Boolean
   ) extends SbtCommandArgs
 
   object DefaultValues {

--- a/shared/src/it/scala/com/nitro/nmesos/commands/ReleaseCommandIntegrationTest.scala
+++ b/shared/src/it/scala/com/nitro/nmesos/commands/ReleaseCommandIntegrationTest.scala
@@ -19,7 +19,6 @@ import org.specs2.mutable.Specification
 class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
   sequential
 
-
   "Deploy Command" should {
 
     "Fail with a friendly message if it can't connect to Singularity" in {
@@ -32,7 +31,8 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       )
       val result = command.run()
 
-      val ExpectedError = CommandError("Unable to connect to http://invalid-api")
+      val ExpectedError =
+        CommandError("Unable to connect to http://invalid-api")
       result must be equalTo ExpectedError
     }
 
@@ -49,7 +49,9 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       )
       val result = command.run()
 
-      result must be equalTo CommandSuccess("Successfully deployed to 1 instances. [dry-run true] use --dry-run false")
+      result must be equalTo CommandSuccess(
+        "Successfully deployed to 1 instances. [dry-run true] use --dry-run false"
+      )
 
       val ExpectedOutput =
         s"""Deploying Config ---------------------------------------------------------------
@@ -90,11 +92,10 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       compareOutput(ExpectedOutput, logger)
     }
 
-
     "deploy a example service for the first time with an expected log" in {
 
-
-      val serviceConfig = buildConfig("example-service").copy(serviceName = ServiceNameInThisTest)
+      val serviceConfig =
+        buildConfig("example-service").copy(serviceName = ServiceNameInThisTest)
 
       val logger = new DummyLogger
       val command = ReleaseCommand(
@@ -106,9 +107,12 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       )
       val result = command.run()
 
-      result must be equalTo CommandSuccess("Successfully deployed to 1 instances.")
+      result must be equalTo CommandSuccess(
+        "Successfully deployed to 1 instances."
+      )
 
-      val ExpectedRequestId = ModelConversions.toSingularityRequestId(serviceConfig)
+      val ExpectedRequestId =
+        ModelConversions.toSingularityRequestId(serviceConfig)
 
       val ExpectedOutput =
         s"""Deploying Config ---------------------------------------------------------------
@@ -157,11 +161,11 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       compareOutput(ExpectedOutput, logger)
     }
 
-
     "Ask for '--force' when deploying an existing service with the same version." in {
 
       // create a new service (in case it doesn't exist already
-      val serviceConfig = buildConfig("example-service").copy(serviceName = ServiceNameInThisTest)
+      val serviceConfig =
+        buildConfig("example-service").copy(serviceName = ServiceNameInThisTest)
       val command = ReleaseCommand(
         serviceConfig,
         InfoLogger,
@@ -170,7 +174,6 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
         deprecatedHardGracePeriod = 20
       )
       val result = command.run()
-
 
       // After the first deploy we try to deploy again.
       val logger = new DummyLogger
@@ -182,14 +185,19 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
         deprecatedHardGracePeriod = 20
       )
       val result2 = command2.run()
-      val ExpectedRequestId = ModelConversions.toSingularityRequestId(serviceConfig)
-      val ExpectedError = CommandError(s"Unable to deploy - There is already a deploy with id latest_${HashExampleService}, use --force to force the redeploy")
+      val ExpectedRequestId =
+        ModelConversions.toSingularityRequestId(serviceConfig)
+      val ExpectedError = CommandError(
+        s"Unable to deploy - There is already a deploy with id latest_${HashExampleService}, use --force to force the redeploy"
+      )
       result2 must be equalTo ExpectedError
     }
 
     // Example of a no standard project (using extra docker parameters)
     "deploy sidecar with an expected log" in {
-      val serviceConfig = buildConfig("sidecar").copy(serviceName = s"test-sidecar-${System.currentTimeMillis}")
+      val serviceConfig = buildConfig("sidecar").copy(serviceName =
+        s"test-sidecar-${System.currentTimeMillis}"
+      )
 
       val command = ReleaseCommand(
         serviceConfig,
@@ -200,15 +208,18 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       )
       val result = command.run()
 
-      result must be equalTo CommandSuccess("Successfully deployed to 1 instances.")
+      result must be equalTo CommandSuccess(
+        "Successfully deployed to 1 instances."
+      )
     }
 
     "deploy a job for the first time with an expected log" in {
 
+      val serviceConfig = buildConfig("example-job").copy(serviceName =
+        JobNameInThisTest
+      ) //.copy(force = true)//.
 
-      val serviceConfig = buildConfig("example-job").copy(serviceName = JobNameInThisTest) //.copy(force = true)//.
-
-      val logger =  new DummyLogger
+      val logger = new DummyLogger
       val command = ReleaseCommand(
         serviceConfig,
         logger,
@@ -218,9 +229,12 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
       )
       val result = command.run()
 
-      result must be equalTo CommandSuccess("Successfully scheduled - cron: '*/5 * * * *'.")
+      result must be equalTo CommandSuccess(
+        "Successfully scheduled - cron: '*/5 * * * *'."
+      )
 
-      val ExpectedRequestId = ModelConversions.toSingularityRequestId(serviceConfig)
+      val ExpectedRequestId =
+        ModelConversions.toSingularityRequestId(serviceConfig)
 
       val ExpectedOutput =
         s"""Deploying Config ---------------------------------------------------------------
@@ -269,7 +283,6 @@ class ReleaseCommandIntegrationTest extends ReleaseCommandFixtures {
   }
 }
 
-
 trait ReleaseCommandFixtures extends Specification {
 
   val JobNameInThisTest = s"integration-test-job-${System.currentTimeMillis}"
@@ -288,15 +301,24 @@ trait ReleaseCommandFixtures extends Specification {
     )
   }
 
-
   val HashExampleService = "17d5246"
   val HashExampleJobConfigFile = "8d4c0de"
 
   def buildConfig(serviceName: String) = {
-    val yamlFile = new File(getClass.getResource(s"/config/$serviceName.yml").toURI)
+    val yamlFile = new File(
+      getClass.getResource(s"/config/$serviceName.yml").toURI
+    )
     ConfigReader.parseEnvironment(yamlFile, "dev", InfoLogger) match {
       case validConfig: ValidConfig =>
-        CmdConfig(serviceName, "latest", force = false, validConfig.environmentName, validConfig.environment, validConfig.fileHash, yamlFile)
+        CmdConfig(
+          serviceName,
+          "latest",
+          force = false,
+          validConfig.environmentName,
+          validConfig.environment,
+          validConfig.fileHash,
+          yamlFile
+        )
       case other => sys.error(other.toString)
     }
 
@@ -308,29 +330,32 @@ trait ReleaseCommandFixtures extends Specification {
 
     def debug(msg: => Any): Unit = {}
 
-    override def println(msg: => Any): Unit = buffer :+= {
-      Console.println(msg)
-      msg.toString
-    }
+    override def println(msg: => Any): Unit =
+      buffer :+= {
+        Console.println(msg)
+        msg.toString
+      }
 
   }
 
   def compareOutput(expectedOutput: String, logger: DummyLogger) = {
     def isLineToIgnore(line: String): Boolean = {
-      line.startsWith(" Config File:") || line.contains("TaskId:") || line.contains("localhost:")
+      line.startsWith(" Config File:") || line.contains("TaskId:") || line
+        .contains("localhost:")
     }
 
+    val expectedLines =
+      expectedOutput.stripMargin.split("\n").filterNot(isLineToIgnore)
+    val outputLines =
+      logger.buffer.mkString("\n").split("\n").toSeq.filterNot(isLineToIgnore)
 
-    val expectedLines = expectedOutput.stripMargin.split("\n").filterNot(isLineToIgnore)
-    val outputLines = logger.buffer.mkString("\n").split("\n").toSeq.filterNot(isLineToIgnore)
-
-    outputLines.zip(expectedLines).foreach { case (expectedLine, outputLine) =>
-      println(s"Out:      [$outputLine]")
-      println(s"Expected: [$expectedLine]")
-      expectedLine must be equalTo outputLine
+    outputLines.zip(expectedLines).foreach {
+      case (expectedLine, outputLine) =>
+        println(s"Out:      [$outputLine]")
+        println(s"Expected: [$expectedLine]")
+        expectedLine must be equalTo outputLine
     }
     outputLines must be equalTo expectedLines
   }
-
 
 }

--- a/shared/src/main/scala/com/nitro/nmesos/commands/BaseCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/BaseCommand.scala
@@ -3,19 +3,24 @@ package com.nitro.nmesos.commands
 import com.nitro.nmesos.config.model.CmdConfig
 import com.nitro.nmesos.singularity.SingularityManager
 import com.nitro.nmesos.singularity.model.SingularityRequestParent.SingularityActiveDeployResponse
-import com.nitro.nmesos.singularity.model.{ SingularityRequest, SingularityResources, SingularityUpdateResult }
+import com.nitro.nmesos.singularity.model.{
+  SingularityRequest,
+  SingularityResources,
+  SingularityUpdateResult
+}
 import com.nitro.nmesos.util.Logger
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 sealed trait CommandResult
 case class CommandSuccess(msg: String) extends CommandResult
 case class CommandError(msg: String) extends CommandResult
 
 trait Command {
+
   /**
-   * Main entry point for all the commands.
-   */
+    * Main entry point for all the commands.
+    */
   def run(): CommandResult
 }
 
@@ -24,16 +29,20 @@ trait BaseCommand extends Command {
   val log: Logger
   val isDryrun: Boolean
 
-  val manager = SingularityManager(localConfig.environment.singularity, log, isDryrun = isDryrun)
+  val manager = SingularityManager(
+    localConfig.environment.singularity,
+    log,
+    isDryrun = isDryrun
+  )
 
   /**
-   * Concrete Command implementation
-   */
+    * Concrete Command implementation
+    */
   protected def processCmd(): CommandResult
 
   /**
-   * Main entry point for all the commands.
-   */
+    * Main entry point for all the commands.
+    */
   def run(): CommandResult = {
 
     showCommand()
@@ -41,7 +50,9 @@ trait BaseCommand extends Command {
     // Check visibility before attempting to process the command.
     manager.ping() match {
       case Failure(_) =>
-        CommandError(s"Unable to connect to ${localConfig.environment.singularity.url}")
+        CommandError(
+          s"Unable to connect to ${localConfig.environment.singularity.url}"
+        )
       case Success(_) =>
         processCmd()
     }
@@ -57,24 +68,34 @@ trait BaseCommand extends Command {
            | dry-run:      ${isDryrun}
            | force:        ${localConfig.force}
            | image:        ${localConfig.environment.container.image}:${localConfig.tag}
-           | api:          ${localConfig.environment.singularity.url}""".stripMargin)
+           | api:          ${localConfig.environment.singularity.url}""".stripMargin
+      )
     }
   }
 
-  def getRemoteRequest(localRequest: SingularityRequest): Try[Option[SingularityRequest]] = {
+  def getRemoteRequest(
+      localRequest: SingularityRequest
+  ): Try[Option[SingularityRequest]] = {
     log.debug("Fetching the remote request configuration...")
     manager.getSingularityRequest(localRequest.id).map(_.map(_.request))
   }
 
-  def getActiveDeploy(localRequest: SingularityRequest): Try[Option[SingularityActiveDeployResponse]] = {
+  def getActiveDeploy(
+      localRequest: SingularityRequest
+  ): Try[Option[SingularityActiveDeployResponse]] = {
     log.debug("Fetching the remote active deploy...")
-    manager.getSingularityRequest(localRequest.id).map(_.flatMap(_.activeDeploy))
+    manager
+      .getSingularityRequest(localRequest.id)
+      .map(_.flatMap(_.activeDeploy))
   }
 
   /**
-   * Create or update the Singularity request based on the diff between local and remote.
-   */
-  def updateSingularityRequestIfNeeded(remoteOpt: Option[SingularityRequest], local: SingularityRequest) = {
+    * Create or update the Singularity request based on the diff between local and remote.
+    */
+  def updateSingularityRequestIfNeeded(
+      remoteOpt: Option[SingularityRequest],
+      local: SingularityRequest
+  ) = {
     log.debug("Comparing remote and local configuration...")
     remoteOpt match {
       case None =>
@@ -87,16 +108,23 @@ trait BaseCommand extends Command {
 
       case Some(other) =>
         // Remote Singularity Request is up to date, nothing to do here!
-        Success(log.info(s" The request configuration for '${localConfig.serviceName}' is up to date! [requestId: ${other.id}]"))
+        Success(
+          log.info(
+            s" The request configuration for '${localConfig.serviceName}' is up to date! [requestId: ${other.id}]"
+          )
+        )
         Success(local)
     }
   }
 
   /**
-   * Scale the resources of the Singularity request based on the diff between local and remote.
-   * Note: Only the number of instances will be updated.
-   */
-  def scaleSingularityRequestIfNeeded(remoteOpt: Option[SingularityRequest], local: SingularityRequest): Try[SingularityRequest] = {
+    * Scale the resources of the Singularity request based on the diff between local and remote.
+    * Note: Only the number of instances will be updated.
+    */
+  def scaleSingularityRequestIfNeeded(
+      remoteOpt: Option[SingularityRequest],
+      local: SingularityRequest
+  ): Try[SingularityRequest] = {
 
     log.debug("Comparing remote and local configuration...")
 
@@ -105,7 +133,11 @@ trait BaseCommand extends Command {
         Failure(new Exception(s" No Mesos config found with id: '${local.id}'"))
 
       case Some(SingularityRequest(_, _, "SPREAD_ALL_SLAVES", _, _, _, _, _)) =>
-        Failure(new Exception(s" Unable to scale to a fix number of instances. Using auto-scale [slavePlacement: SPREAD_ALL_SLAVES]"))
+        Failure(
+          new Exception(
+            s" Unable to scale to a fix number of instances. Using auto-scale [slavePlacement: SPREAD_ALL_SLAVES]"
+          )
+        )
 
       case Some(remote) if (remote.instances != local.instances) =>
         // Remote Singularity request exist but num instances need to be scaled
@@ -113,11 +145,17 @@ trait BaseCommand extends Command {
 
       case Some(other) =>
         // Remote Singularity Request is up to date, nothing to do here!
-        Success(log.info(s" The request configuration for '${localConfig.serviceName}' is up to date! [requestId: ${other.id}]"))
+        Success(
+          log.info(
+            s" The request configuration for '${localConfig.serviceName}' is up to date! [requestId: ${other.id}]"
+          )
+        )
         Success(local)
     }
   }
 
-  def dryWarning = if (isDryrun) log.importantColor(" [dry-run true] use --dry-run false") else ""
+  def dryWarning =
+    if (isDryrun) log.importantColor(" [dry-run true] use --dry-run false")
+    else ""
 
 }

--- a/shared/src/main/scala/com/nitro/nmesos/commands/CheckCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/CheckCommand.scala
@@ -2,28 +2,33 @@ package com.nitro.nmesos.commands
 
 import com.nitro.nmesos.config.model.CmdConfig
 import com.nitro.nmesos.util.Logger
-import com.nitro.nmesos.config.{ Fail, Validations, Warning }
+import com.nitro.nmesos.config.{Fail, Validations, Warning}
 
 /**
- * Verify the configuration without any external call.
- */
+  * Verify the configuration without any external call.
+  */
 case class CheckCommand(
-  localConfig: CmdConfig,
-  log: Logger,
-  isDryrun: Boolean,
-  deprecatedSoftGracePeriod: Int,
-  deprecatedHardGracePeriod: Int) extends BaseCommand {
+    localConfig: CmdConfig,
+    log: Logger,
+    isDryrun: Boolean,
+    deprecatedSoftGracePeriod: Int,
+    deprecatedHardGracePeriod: Int
+) extends BaseCommand {
 
   override protected def processCmd(): CommandResult = {
     log.logBlock("Checking...") {
-      val checks = Validations.checkAll(localConfig, (deprecatedSoftGracePeriod, deprecatedHardGracePeriod))
+      val checks = Validations.checkAll(
+        localConfig,
+        (deprecatedSoftGracePeriod, deprecatedHardGracePeriod)
+      )
       val errors = checks.collect { case f: Fail => f }
       val warnings = checks.collect { case f: Warning => f }
       Validations.logResult(checks, log)
 
-      if (errors.isEmpty) CommandSuccess(s"Valid config with ${warnings.size} warnings") else CommandError(s"${errors.size} errors found")
+      if (errors.isEmpty)
+        CommandSuccess(s"Valid config with ${warnings.size} warnings")
+      else CommandError(s"${errors.size} errors found")
     }
   }
 
 }
-

--- a/shared/src/main/scala/com/nitro/nmesos/commands/ReleaseCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/ReleaseCommand.scala
@@ -1,39 +1,45 @@
 package com.nitro.nmesos.commands
 
-import com.nitro.nmesos.config.{ Fail, Validations }
+import com.nitro.nmesos.config.{Fail, Validations}
 import com.nitro.nmesos.config.model.CmdConfig
 import com.nitro.nmesos.singularity.model._
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import com.nitro.nmesos.singularity.ModelConversions._
-import com.nitro.nmesos.util.{ Logger, WaitUtil }
+import com.nitro.nmesos.util.{Logger, WaitUtil}
 import com.nitro.nmesos.util.Conversions._
 
 import scala.annotation.tailrec
 
 /**
- * Command to deploy a service to Mesos.
- * Features:
- *  - Create or update the Singularity Request if needed.
- *  - Scale up/down the Singularity Request/Deploy if needed.
- *  - Check if the deploy already exist. (require force action for redeploy)
- *  - Run in dryrun mode or real mode.
- *  - deploy a new version of the service
- *  - show Mesos task status.
- */
+  * Command to deploy a service to Mesos.
+  * Features:
+  *  - Create or update the Singularity Request if needed.
+  *  - Scale up/down the Singularity Request/Deploy if needed.
+  *  - Check if the deploy already exist. (require force action for redeploy)
+  *  - Run in dryrun mode or real mode.
+  *  - deploy a new version of the service
+  *  - show Mesos task status.
+  */
 case class ReleaseCommand(
-  localConfig: CmdConfig,
-  log: Logger,
-  isDryrun: Boolean,
-  deprecatedSoftGracePeriod: Int,
-  deprecatedHardGracePeriod: Int) extends DeployCommandHelper {
+    localConfig: CmdConfig,
+    log: Logger,
+    isDryrun: Boolean,
+    deprecatedSoftGracePeriod: Int,
+    deprecatedHardGracePeriod: Int
+) extends DeployCommandHelper {
 
-  def verifyCommand(): Try[Unit] = log.logBlock("Verifying") {
-    val checks = Validations.checkAll(localConfig, (deprecatedSoftGracePeriod, deprecatedHardGracePeriod))
-    val errors = checks.collect { case f: Fail => f }
-    Validations.logResult(checks, log)
-    if (errors.isEmpty) Success(()) else Failure(new Exception(s"Invalid Config"))
-  }
+  def verifyCommand(): Try[Unit] =
+    log.logBlock("Verifying") {
+      val checks = Validations.checkAll(
+        localConfig,
+        (deprecatedSoftGracePeriod, deprecatedHardGracePeriod)
+      )
+      val errors = checks.collect { case f: Fail => f }
+      Validations.logResult(checks, log)
+      if (errors.isEmpty) Success(())
+      else Failure(new Exception(s"Invalid Config"))
+    }
 
   def processCmd(): CommandResult = {
 
@@ -51,7 +57,8 @@ case class ReleaseCommand(
       for {
         _ <- isValid
         remoteRequest <- getRemoteRequest(localRequest)
-        updatedRequest <- updateSingularityRequestIfNeeded(remoteRequest, localRequest)
+        updatedRequest <-
+          updateSingularityRequestIfNeeded(remoteRequest, localRequest)
 
         deployedId <- deployVersionIfNeeded(updatedRequest)
       } yield deployedId
@@ -61,17 +68,29 @@ case class ReleaseCommand(
     // Show Mesos task info
     val tryShowDeployStatus = for {
       deployId <- tryDeployId
-      isSuccess <- if (!isDryrun) showFinalDeployStatus(localRequest, deployId) else Success(true)
-      _ <- if (!isDryrun && !isSuccess) showLogs(localRequest, deployId) else Success(true)
+      isSuccess <-
+        if (!isDryrun) showFinalDeployStatus(localRequest, deployId)
+        else Success(true)
+      _ <-
+        if (!isDryrun && !isSuccess) showLogs(localRequest, deployId)
+        else Success(true)
     } yield {
       isSuccess
     }
 
     tryShowDeployStatus match {
       case Success(true) if (localRequest.schedule.isEmpty) =>
-        CommandSuccess(s"""Successfully deployed to ${localRequest.instances.getOrElse("")} instances.$dryWarning""")
+        CommandSuccess(
+          s"""Successfully deployed to ${localRequest.instances.getOrElse(
+            ""
+          )} instances.$dryWarning"""
+        )
       case Success(true) if (localRequest.schedule.isDefined) =>
-        CommandSuccess(s"""Successfully scheduled - cron: '${localRequest.schedule.getOrElse("")}'.$dryWarning""")
+        CommandSuccess(
+          s"""Successfully scheduled - cron: '${localRequest.schedule.getOrElse(
+            ""
+          )}'.$dryWarning"""
+        )
       case Success(false) =>
         CommandError(s"Unable to deploy")
       case Failure(ex) =>
@@ -83,8 +102,8 @@ case class ReleaseCommand(
 trait DeployCommandHelper extends BaseCommand {
 
   /**
-   * Compare remote deploy running and desired deploy, deploying a new Singularity Deploy if needed.
-   */
+    * Compare remote deploy running and desired deploy, deploying a new Singularity Deploy if needed.
+    */
   def deployVersionIfNeeded(local: SingularityRequest): Try[DeployId] = {
     val defaultId = defaultDeployId(localConfig)
 
@@ -96,7 +115,9 @@ trait DeployCommandHelper extends BaseCommand {
         val localDeploy = toSingularityDeploy(localConfig, defaultId)
         val newImage = localDeploy.containerInfo.docker.image
         val message = s" Deploying version '$newImage'"
-        manager.deploySingularityDeploy(local, localDeploy, message).map(_ => localDeploy.id)
+        manager
+          .deploySingularityDeploy(local, localDeploy, message)
+          .map(_ => localDeploy.id)
 
       case Some(_) =>
         // Already a deploy with same id, force required.
@@ -104,15 +125,25 @@ trait DeployCommandHelper extends BaseCommand {
           val deployId = generateRandomDeployId(defaultId)
           val localDeploy = toSingularityDeploy(localConfig, deployId)
 
-          log.info(s" There is already a deploy with id $defaultId , forcing deploy with new id '$deployId'")
+          log.info(
+            s" There is already a deploy with id $defaultId , forcing deploy with new id '$deployId'"
+          )
           val newImage = localDeploy.containerInfo.docker.image
           val message = s" Redeploy of $deployId forced. Image: $newImage"
 
-          manager.deploySingularityDeploy(local, localDeploy, message).map(_ => localDeploy.id)
+          manager
+            .deploySingularityDeploy(local, localDeploy, message)
+            .map(_ => localDeploy.id)
 
         } else {
-          log.info(s" There is already a deploy with same id '$defaultId' for request '${local.id}'")
-          Failure(sys.error(s"There is already a deploy with id $defaultId, use --force to force the redeploy"))
+          log.info(
+            s" There is already a deploy with same id '$defaultId' for request '${local.id}'"
+          )
+          Failure(
+            sys.error(
+              s"There is already a deploy with id $defaultId, use --force to force the redeploy"
+            )
+          )
         }
 
     }
@@ -120,9 +151,14 @@ trait DeployCommandHelper extends BaseCommand {
   }
 
   // Show the Mesos TaskId and final deploy status.
-  final def showFinalDeployStatus(request: SingularityRequest, deployId: DeployId): Try[Boolean] = {
+  final def showFinalDeployStatus(
+      request: SingularityRequest,
+      deployId: DeployId
+  ): Try[Boolean] = {
     log.logBlock("Mesos Tasks Info") {
-      log.info(s" Deploy progress at ${localConfig.environment.singularity.url}/request/${request.id}/deploy/$deployId")
+      log.info(
+        s" Deploy progress at ${localConfig.environment.singularity.url}/request/${request.id}/deploy/$deployId"
+      )
 
       val managerWithoutLogger = manager.withDisabledDebugLog()
 
@@ -130,11 +166,15 @@ trait DeployCommandHelper extends BaseCommand {
       // Wait until the pending task are executed.
       def fetchMessage() = {
         for {
-          pending <- managerWithoutLogger.getSingularityPendingDeploy(request.id, deployId).getOrElse(None)
+          pending <-
+            managerWithoutLogger
+              .getSingularityPendingDeploy(request.id, deployId)
+              .getOrElse(None)
         } yield {
           val count = pending.deployProgress.targetActiveInstances
           val status = pending.currentDeployState
-          s"""Waiting until the deploy is completed [deployId: '$deployId', status: $status, instances ${count}/${request.instances.getOrElse("*")}]"""
+          s"""Waiting until the deploy is completed [deployId: '$deployId', status: $status, instances ${count}/${request.instances
+            .getOrElse("*")}]"""
         }
       }
 
@@ -144,7 +184,8 @@ trait DeployCommandHelper extends BaseCommand {
       WaitUtil.waitUntil {
         log.debug(s"Waiting for the deploy result...")
         for {
-          deployInfo <- manager.getSingularityDeployHistory(request.id, deployId)
+          deployInfo <-
+            manager.getSingularityDeployHistory(request.id, deployId)
         } yield {
           deployInfo.flatMap(_.deployResult).isDefined
         }
@@ -157,8 +198,10 @@ trait DeployCommandHelper extends BaseCommand {
         deployInfo <- manager.getSingularityDeployHistory(request.id, deployId)
         activeTasks <- managerWithoutLogger.getActiveTasks(request)
       } yield {
-        val deploy = deployInfo.getOrElse(sys.error(s"Unable to find deployId $deployId"))
-        val deployResult = deploy.deployResult.getOrElse(sys.error(s"Missing deploy result."))
+        val deploy =
+          deployInfo.getOrElse(sys.error(s"Unable to find deployId $deployId"))
+        val deployResult =
+          deploy.deployResult.getOrElse(sys.error(s"Missing deploy result."))
 
         localConfig.environment.singularity.schedule match {
           case None =>
@@ -178,15 +221,28 @@ trait DeployCommandHelper extends BaseCommand {
     }
   }
 
-  private def logJobInfo(request: SingularityRequest, deployResult: SingularityDeployResult, schedule: String) = {
-    log.println(s""" Scheduled Mesos Job State: ${log.importantColor(deployResult.deployState)}""")
-    log.println(s"   * History: ${localConfig.environment.singularity.url}/request/${request.id}")
+  private def logJobInfo(
+      request: SingularityRequest,
+      deployResult: SingularityDeployResult,
+      schedule: String
+  ) = {
+    log.println(s""" Scheduled Mesos Job State: ${log.importantColor(
+      deployResult.deployState
+    )}""")
+    log.println(
+      s"   * History: ${localConfig.environment.singularity.url}/request/${request.id}"
+    )
     log.println(s"   * Cron:    '$schedule'")
   }
 
-  private def logTaskInfo(deployResult: SingularityDeployResult, successfulTasks: Seq[SingularityTask]) = {
+  private def logTaskInfo(
+      deployResult: SingularityDeployResult,
+      successfulTasks: Seq[SingularityTask]
+  ) = {
     val message = deployResult.message.map(msg => s" - $msg").getOrElse("")
-    log.println(s""" Deploy Mesos Deploy State: ${log.importantColor(deployResult.deployState)}$message""")
+    log.println(s""" Deploy Mesos Deploy State: ${log.importantColor(
+      deployResult.deployState
+    )}$message""")
 
     deployResult.deployFailures.sortBy(_.taskId.instanceNo).foreach { failure =>
       log.println(s"   * TaskId: ${log.infoColor(failure.taskId.id)}")
@@ -198,7 +254,9 @@ trait DeployCommandHelper extends BaseCommand {
     successfulTasks.foreach { task =>
       log.println(s"""   * TaskId: ${log.infoColor(task.taskId.id)}""")
       task.mesosTask.container.docker.portMappings.foreach { port =>
-        log.println(s"""     - ${task.offer.hostname}:${port.hostPort}  -> ${port.containerPort}""")
+        log.println(
+          s"""     - ${task.offer.hostname}:${port.hostPort}  -> ${port.containerPort}"""
+        )
       }
     }
   }
@@ -209,7 +267,9 @@ trait DeployCommandHelper extends BaseCommand {
       activeTask <- manager.getActiveTasks(request)
       tasks <- manager.getSingularityTaskHistory(request.id, deployId)
     } yield {
-      val taskOption = tasks.map(_.taskId) ++ activeTask.map(_.taskId).headOption // show logs only for the first task
+      val taskOption = tasks.map(_.taskId) ++ activeTask
+        .map(_.taskId)
+        .headOption // show logs only for the first task
       taskOption.foreach(taskId => showLog(taskId))
     }
   }.recover {
@@ -220,8 +280,10 @@ trait DeployCommandHelper extends BaseCommand {
 
   // Fetch and print logs for the given task
   def showLog(taskId: SingularityTaskId) = {
-    val logsStdOut = manager.getLogs(taskId = taskId.id, path = "stdout").getOrElse(Seq.empty)
-    val logsStdErr = manager.getLogs(taskId = taskId.id, path = "stderr").getOrElse(Seq.empty)
+    val logsStdOut =
+      manager.getLogs(taskId = taskId.id, path = "stdout").getOrElse(Seq.empty)
+    val logsStdErr =
+      manager.getLogs(taskId = taskId.id, path = "stderr").getOrElse(Seq.empty)
 
     log.logBlock("Log - stderr") {
       logsStdErr.foreach(line => log.println(s" $line"))

--- a/shared/src/main/scala/com/nitro/nmesos/commands/RunLocalCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/RunLocalCommand.scala
@@ -13,9 +13,7 @@ import com.nitro.nmesos.singularity.ModelConversions
 case class RunLocalCommand(
     localConfig: CmdConfig,
     log: Logger,
-    isDryrun: Boolean,
-    deprecatedSoftGracePeriod: Int,
-    deprecatedHardGracePeriod: Int
+    isDryrun: Boolean
 ) extends BaseCommand {
 
   override def run(): CommandResult = {

--- a/shared/src/main/scala/com/nitro/nmesos/commands/RunLocalCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/RunLocalCommand.scala
@@ -1,0 +1,62 @@
+package com.nitro.nmesos.commands
+
+import com.nitro.nmesos.config.model.CmdConfig
+import com.nitro.nmesos.util.Logger
+import com.nitro.nmesos.config.{Fail, Validations, Warning}
+import sys.process._
+import scala.language.postfixOps
+import com.nitro.nmesos.singularity.ModelConversions
+
+/**
+  * Run the service locally
+  */
+case class RunLocalCommand(
+    localConfig: CmdConfig,
+    log: Logger,
+    isDryrun: Boolean,
+    deprecatedSoftGracePeriod: Int,
+    deprecatedHardGracePeriod: Int
+) extends BaseCommand {
+
+  override def run(): CommandResult = {
+    showCommand()
+    processCmd()
+  }
+
+  def runLocalCmdString(): String = {
+    val envVarString = localConfig.environment.container.env_vars.get
+      .map { case (key, value) => s"""-e ${key}=${value}""" }
+      .mkString(" ")
+
+    val containerInfo = ModelConversions.toSingularityContainerInfo(localConfig)
+    val imageWithTag = containerInfo.docker.image
+    val portMappings = containerInfo.docker.portMappings
+      .map(pm => s"-p ${pm.containerPort}:${pm.containerPort}")
+      .mkString(" ")
+
+    s"docker run -i ${portMappings} ${envVarString} ${imageWithTag}"
+  }
+
+  private def showCommand() = {
+    log.logBlock("Local deploy for config") {
+      log.info(
+        s""" Service Name: ${localConfig.serviceName}
+           | Config File:  ${localConfig.file.getAbsolutePath}
+           | environment:  ${localConfig.environmentName}
+           | image:        ${localConfig.environment.container.image}:${localConfig.tag}
+           | docker cmd:   ${runLocalCmdString()}
+           """
+      )
+    }
+  }
+
+  override def processCmd(): CommandResult = {
+    val runLocal = (runLocalCmdString() !)
+    if (runLocal == 0) {
+      CommandSuccess(s"""Successfully deployed locally""")
+    } else {
+      CommandError(s"Unable to deploy locally")
+    }
+  }
+
+}

--- a/shared/src/main/scala/com/nitro/nmesos/commands/ScaleCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/ScaleCommand.scala
@@ -1,19 +1,26 @@
 package com.nitro.nmesos.commands
 
 import com.nitro.nmesos.config.model.CmdConfig
-import com.nitro.nmesos.singularity.ModelConversions.{ DeployId, toSingularityRequest }
-import com.nitro.nmesos.singularity.model.{ SingularityRequest, SingularityResources }
+import com.nitro.nmesos.singularity.ModelConversions.{
+  DeployId,
+  toSingularityRequest
+}
+import com.nitro.nmesos.singularity.model.{
+  SingularityRequest,
+  SingularityResources
+}
 import com.nitro.nmesos.util.Logger
 import com.nitro.nmesos.singularity.ModelConversions._
 import com.nitro.nmesos.singularity.model.SingularityRequestParent.SingularityActiveDeployResponse
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
- * Command to scale up/down a service in Mesos.
- * Will change resources (cpu, memory, instances) but keeping the some version already deployed.
- */
-case class ScaleCommand(localConfig: CmdConfig, log: Logger, isDryrun: Boolean) extends ScaleCommandHelper {
+  * Command to scale up/down a service in Mesos.
+  * Will change resources (cpu, memory, instances) but keeping the some version already deployed.
+  */
+case class ScaleCommand(localConfig: CmdConfig, log: Logger, isDryrun: Boolean)
+    extends ScaleCommandHelper {
 
   def processCmd(): CommandResult = {
 
@@ -28,14 +35,19 @@ case class ScaleCommand(localConfig: CmdConfig, log: Logger, isDryrun: Boolean) 
     val tryScale: Try[String] = log.logBlock("Applying Scale Config!") {
       for {
         remoteRequest <- getRemoteRequest(localRequest)
-        updatedRequest <- scaleSingularityRequestIfNeeded(remoteRequest, localRequest)
+        updatedRequest <-
+          scaleSingularityRequestIfNeeded(remoteRequest, localRequest)
         _ <- scaleDeployIfNeeded(localRequest)
       } yield updatedRequest.id
     }
 
     tryScale match {
       case Success(_) =>
-        CommandSuccess(s"""Successfully scaled to ${localRequest.instances.getOrElse("0")} instances.$dryWarning""")
+        CommandSuccess(
+          s"""Successfully scaled to ${localRequest.instances.getOrElse(
+            "0"
+          )} instances.$dryWarning"""
+        )
       case Failure(ex) =>
         CommandError(s"Unable to deploy - ${ex.getMessage}")
     }
@@ -43,10 +55,11 @@ case class ScaleCommand(localConfig: CmdConfig, log: Logger, isDryrun: Boolean) 
 }
 
 trait ScaleCommandHelper extends BaseCommand {
+
   /**
-   * Compare remote deploy running and desired deploy,
-   * deploying a new Singularity Deploy if needed (to update cpus/ or memory).
-   */
+    * Compare remote deploy running and desired deploy,
+    * deploying a new Singularity Deploy if needed (to update cpus/ or memory).
+    */
   def scaleDeployIfNeeded(localRequest: SingularityRequest): Try[Unit] = {
 
     log.debug(s"Checking if there is already an active deploy...")
@@ -56,28 +69,37 @@ trait ScaleCommandHelper extends BaseCommand {
         log.info(s"There is no active deploy for request: '${localRequest.id}'")
         Success(()) // no deploy to scale.
 
-      case Some(SingularityActiveDeployResponse(remoteDeployId, remoteResources)) =>
-
+      case Some(
+            SingularityActiveDeployResponse(remoteDeployId, remoteResources)
+          ) =>
         val localResource = toSingularityResources(localConfig.environment)
 
         // Already a deploy with same id, force required.
-        if (remoteResources.memoryMb != localResource.memoryMb ||
+        if (
+          remoteResources.memoryMb != localResource.memoryMb ||
           remoteResources.cpus != localResource.cpus ||
           remoteResources.numPorts != localResource.numPorts ||
-          remoteResources.diskMb != localResource.diskMb) {
-          log.info(s" Current deploy '$remoteDeployId' is not using the required resources")
+          remoteResources.diskMb != localResource.diskMb
+        ) {
+          log.info(
+            s" Current deploy '$remoteDeployId' is not using the required resources"
+          )
           log.info(
             s""" Changes to apply:
                |   * memoryMb:  ${remoteResources.memoryMb}   -> ${localResource.memoryMb}
-               |   * cpus:      ${remoteResources.cpus}     -> ${localResource.cpus}""".stripMargin)
+               |   * cpus:      ${remoteResources.cpus}     -> ${localResource.cpus}""".stripMargin
+          )
 
-          val localDeploy = toSingularityDeploy(localConfig, scaleDeployId(remoteDeployId))
-          val message = s"Auto scaling deploy '$remoteDeployId' [memoryMb: ${remoteResources.memoryMb}->${localResource.memoryMb}, cpus:${remoteResources.cpus}->${localResource.cpus}]"
-          manager.deploySingularityDeploy(localRequest, localDeploy, message).map(_ => {})
+          val localDeploy =
+            toSingularityDeploy(localConfig, scaleDeployId(remoteDeployId))
+          val message =
+            s"Auto scaling deploy '$remoteDeployId' [memoryMb: ${remoteResources.memoryMb}->${localResource.memoryMb}, cpus:${remoteResources.cpus}->${localResource.cpus}]"
+          manager
+            .deploySingularityDeploy(localRequest, localDeploy, message)
+            .map(_ => {})
         } else {
           log.info(s" No need to update the active deploy '$remoteDeployId'")
-          log.info(
-            s""" * memoryMb:  ${localResource.memoryMb}
+          log.info(s""" * memoryMb:  ${localResource.memoryMb}
                | * cpus:      ${localResource.cpus}
                | """.stripMargin)
           Success(())

--- a/shared/src/main/scala/com/nitro/nmesos/commands/VerifyEnvCommand.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/commands/VerifyEnvCommand.scala
@@ -8,16 +8,17 @@ import com.nitro.nmesos.singularity.model.SingularityRequestParent
 import com.nitro.nmesos.util.Logger
 
 import scala.Option.option2Iterable
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 /**
- * Verify a complete Cluster comparing Singularity, Mesos, Docker and Sidecar State.
- */
-case class VerifyEnvCommand(singularityUrl: String, log: Logger) extends Command
-  with VerifyRequests
-  with VerifyContainers
-  with VerifySidecar
-  with FetchEnvironment {
+  * Verify a complete Cluster comparing Singularity, Mesos, Docker and Sidecar State.
+  */
+case class VerifyEnvCommand(singularityUrl: String, log: Logger)
+    extends Command
+    with VerifyRequests
+    with VerifyContainers
+    with VerifySidecar
+    with FetchEnvironment {
 
   def run(): CommandResult = {
 
@@ -43,8 +44,8 @@ case class VerifyEnvCommand(singularityUrl: String, log: Logger) extends Command
 }
 
 /**
- * Gather all needed info from Containers, Sidecar and Singularity.
- */
+  * Gather all needed info from Containers, Sidecar and Singularity.
+  */
 trait FetchEnvironment {
   def singularityUrl: String
   def log: Logger
@@ -52,15 +53,22 @@ trait FetchEnvironment {
   var manager = DryrunSingularityManager(singularityUrl, log)
   var sidecar = SidecarManager(log)
 
-  def fetchInfo() = log.logBlock(s"Analyzing: $singularityUrl") {
-    for {
-      requests <- manager.getSingularityActiveRequests()
-      hosts = requests.flatMap(_.taskIds).flatMap(_.healthy).map(_.sanitizedHost).distinct.map(desanitized)
-      containers = hosts.par.map(fetchContainers).seq.flatten
-      sidecars = fetchSidecarInfo(containers)
-      info = EnvironmentInfo(requests, containers, sidecars)
-    } yield info
-  }
+  def fetchInfo() =
+    log.logBlock(s"Analyzing: $singularityUrl") {
+      for {
+        requests <- manager.getSingularityActiveRequests()
+        hosts =
+          requests
+            .flatMap(_.taskIds)
+            .flatMap(_.healthy)
+            .map(_.sanitizedHost)
+            .distinct
+            .map(desanitized)
+        containers = hosts.par.map(fetchContainers).seq.flatten
+        sidecars = fetchSidecarInfo(containers)
+        info = EnvironmentInfo(requests, containers, sidecars)
+      } yield info
+    }
 
   private def fetchContainers(host: String): Seq[Container] = {
     log.println(s"Fetching Docker container from $host...")
@@ -68,14 +76,21 @@ trait FetchEnvironment {
   }.seq
 
   /**
-   * Recover Sidecar info if Sidecar container pressent
-   */
-  private def fetchSidecarInfo(containers: Seq[Container]): Seq[SidecarServices] = {
-    val sidecarHosts = containers.filter(_.image.contains("gonitro/sidecar")).map(_.host).distinct.sorted
+    * Recover Sidecar info if Sidecar container pressent
+    */
+  private def fetchSidecarInfo(
+      containers: Seq[Container]
+  ): Seq[SidecarServices] = {
+    val sidecarHosts = containers
+      .filter(_.image.contains("gonitro/sidecar"))
+      .map(_.host)
+      .distinct
+      .sorted
     sidecarHosts.map(sidecar.getServices).flatMap(_.toOption.flatten.toSeq)
   }
 
-  private def desanitized(sanitizedHost: String) = sanitizedHost.replaceAll("_", "-")
+  private def desanitized(sanitizedHost: String) =
+    sanitizedHost.replaceAll("_", "-")
 
 }
 
@@ -83,8 +98,8 @@ trait VerifyContainers {
   def log: Logger
 
   /**
-   * Verify all containers running in the cluster belong to a Singularity Requests.
-   */
+    * Verify all containers running in the cluster belong to a Singularity Requests.
+    */
   def verifyOrphanContainers(info: EnvironmentInfo) = {
     log.logBlock(s"Verifying containers") {
 
@@ -93,7 +108,8 @@ trait VerifyContainers {
         .flatMap(_.healthy)
         .map(_.id)
 
-      val runningContainerTaskId = info.containers.filter(_.name.startsWith("mesos-")).map(_.taskId)
+      val runningContainerTaskId =
+        info.containers.filter(_.name.startsWith("mesos-")).map(_.taskId)
       val orphans = runningContainerTaskId.diff(mesosTasksId)
 
       print(info, mesosTasksId, orphans)
@@ -102,15 +118,24 @@ trait VerifyContainers {
     }
   }
 
-  private def print(info: EnvironmentInfo, mesosTasksId: Seq[String], orphans: Seq[String]) = {
+  private def print(
+      info: EnvironmentInfo,
+      mesosTasksId: Seq[String],
+      orphans: Seq[String]
+  ) = {
     if (orphans.isEmpty) {
-      log.println(s" ${log.Ok} All containers belong to a Mesos Task [${info.containers.length} containers, ${mesosTasksId.length} tasks]")
+      log.println(
+        s" ${log.Ok} All containers belong to a Mesos Task [${info.containers.length} containers, ${mesosTasksId.length} tasks]"
+      )
     } else {
       log.error(s" Probably orphan containers:")
 
       orphans.foreach { taskId =>
-        val containerInfo = info.containers.find(_.taskId == taskId)
-          .fold(s"$taskId")(c => s"   at ${c.host} [containerId: ${c.id}, image: ${c.image}, name: ${c.name}]")
+        val containerInfo = info.containers
+          .find(_.taskId == taskId)
+          .fold(s"$taskId")(c =>
+            s"   at ${c.host} [containerId: ${c.id}, image: ${c.image}, name: ${c.name}]"
+          )
         log.error(s" ${log.Fail} $containerInfo")
       }
     }
@@ -121,19 +146,23 @@ trait VerifyRequests {
   def log: Logger
 
   /**
-   * Verify all requests
-   */
+    * Verify all requests
+    */
   def verifyRequests(info: EnvironmentInfo) = {
     log.logBlock(s"Verifying requests") {
-      info.requests.map(verifyRequest(_, info))
+      info.requests
+        .map(verifyRequest(_, info))
         .forall(identity)
     }
   }
 
   /**
-   * Verify all task for the given request have a container running and no orphan containers are found.
-   */
-  def verifyRequest(request: SingularityRequestParent, info: EnvironmentInfo): Boolean = {
+    * Verify all task for the given request have a container running and no orphan containers are found.
+    */
+  def verifyRequest(
+      request: SingularityRequestParent,
+      info: EnvironmentInfo
+  ): Boolean = {
     val tasksCount = request.taskIds.toSeq.flatMap(_.healthy).length
 
     val containersByRequest = info.containers
@@ -149,31 +178,46 @@ trait VerifyRequests {
 
     val orphanContainers = containersByRequest.diff(foundContainers)
 
-    printResult(tasksCount, request.request.id, orphanContainers, foundContainers)
+    printResult(
+      tasksCount,
+      request.request.id,
+      orphanContainers,
+      foundContainers
+    )
 
     orphanContainers.isEmpty
   }
 
   /**
-   * Print to std the output result
-   */
-  def printResult(tasksCount: Int, requestId: String, orphanContainers: Seq[Container], foundContainers: Seq[Container]) = {
+    * Print to std the output result
+    */
+  def printResult(
+      tasksCount: Int,
+      requestId: String,
+      orphanContainers: Seq[Container],
+      foundContainers: Seq[Container]
+  ) = {
 
     if (!orphanContainers.isEmpty) {
-      val orphasInfo = orphanContainers.map(c => s" at ${c.host} [containerId: ${c.id}, name: ${c.name}]")
+      val orphasInfo = orphanContainers
+        .map(c => s" at ${c.host} [containerId: ${c.id}, name: ${c.name}]")
         .mkString("\n\t\t\t")
 
-      val validInfo = foundContainers.map(c => s" at ${c.host} [containerId: ${c.id}]")
+      val validInfo = foundContainers
+        .map(c => s" at ${c.host} [containerId: ${c.id}]")
         .mkString("\n\t\t\t")
 
-      log.error(
-        s""" ${log.Fail} $requestId: $tasksCount tasks, ${log.errorColor(foundContainers.length)} containers found, ${log.errorColor(orphanContainers.length)} unexpected containers
+      log.error(s""" ${log.Fail} $requestId: $tasksCount tasks, ${log
+        .errorColor(foundContainers.length)} containers found, ${log.errorColor(
+        orphanContainers.length
+      )} unexpected containers
            |  orphans:\t${log.errorColor(orphasInfo)}
            |  valid:\t${log.infoColor(validInfo)}
         """.stripMargin)
     } else {
       log.println(
-        s" ${log.Ok} $requestId: $tasksCount tasks, ${log.infoColor(foundContainers.length)} containers found")
+        s" ${log.Ok} $requestId: $tasksCount tasks, ${log.infoColor(foundContainers.length)} containers found"
+      )
     }
   }
 }
@@ -190,9 +234,13 @@ trait VerifySidecar {
 
         // All host are running sidecar
         if (allHost == sidecarHosts) {
-          log.println(s" ${log.Ok} ${sidecarHosts.size} Sidecar instances running ")
+          log.println(
+            s" ${log.Ok} ${sidecarHosts.size} Sidecar instances running "
+          )
         } else {
-          log.println(s" ${log.Fail} ${sidecarHosts.size} Sidecar instances running [${allHost.size} expected]")
+          log.println(
+            s" ${log.Fail} ${sidecarHosts.size} Sidecar instances running [${allHost.size} expected]"
+          )
         }
 
         val inSync = SidecarUtils.verifyInSync(info)

--- a/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
@@ -2,102 +2,141 @@ package com.nitro.nmesos.config
 
 import com.nitro.nmesos.config.model._
 import com.nitro.nmesos.util.Logger
-import java.{ util => ju, text => jt }
-import java.time.{ temporal => jtt }
+import java.{util => ju, text => jt}
+import java.time.{temporal => jtt}
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 // Basic model validations
 object Validations extends ValidationHelper {
 
-  def checkAll(localConfig: CmdConfig, gracePeriods: (Int, Int)): Seq[Validation] = Seq(
-    checkResources(localConfig.environment.resources),
-    checkContainer(localConfig.environment.container),
-    checkScheduledJob(localConfig.environment),
-    checkService(localConfig.environment),
-    checkDeprecated(localConfig.file, LocalDate.now(), gracePeriods)).flatten.sortBy(_.name)
+  def checkAll(
+      localConfig: CmdConfig,
+      gracePeriods: (Int, Int)
+  ): Seq[Validation] =
+    Seq(
+      checkResources(localConfig.environment.resources),
+      checkContainer(localConfig.environment.container),
+      checkScheduledJob(localConfig.environment),
+      checkService(localConfig.environment),
+      checkDeprecated(localConfig.file, LocalDate.now(), gracePeriods)
+    ).flatten.sortBy(_.name)
 
-  def checkResources(resources: Resources): Seq[Validation] = Seq(
-    check("Resources - Memory Instances", "Must be > 0") {
+  def checkResources(resources: Resources): Seq[Validation] =
+    Seq(check("Resources - Memory Instances", "Must be > 0") {
       resources.memoryMb > 0
     })
 
-  def checkService(env: Environment): Seq[Validation] = if (isService(env)) {
-    Seq(
-      check("Resources - Num Instances", "Must be > 0") {
-        env.singularity.slavePlacement.exists(_ == "SPREAD_ALL_SLAVES") || env.resources.instances.exists(_ > 0)
-      },
-      checkWarning("Container - Ports", "Should be defined in HOST mode") {
-        env.container.network.exists(_ == "HOST") || !env.container.ports.toSet.flatten.isEmpty
-      },
-      check("Container - Port values", "Must be >= 0 and <= 65535") {
-        env.container.ports.toSeq.flatten.forall(isValidPort)
-      },
-      check("Container - Network", "Unsupported network") {
-        env.container.network match {
-          case None => true
-          case Some("HOST") | Some("BRIDGE") => true
-          case _ => false
+  def checkService(env: Environment): Seq[Validation] =
+    if (isService(env)) {
+      Seq(
+        check("Resources - Num Instances", "Must be > 0") {
+          env.singularity.slavePlacement.exists(
+            _ == "SPREAD_ALL_SLAVES"
+          ) || env.resources.instances.exists(_ > 0)
+        },
+        checkWarning("Container - Ports", "Should be defined in HOST mode") {
+          env.container.network
+            .exists(_ == "HOST") || !env.container.ports.toSet.flatten.isEmpty
+        },
+        check("Container - Port values", "Must be >= 0 and <= 65535") {
+          env.container.ports.toSeq.flatten.forall(isValidPort)
+        },
+        check("Container - Network", "Unsupported network") {
+          env.container.network match {
+            case None                          => true
+            case Some("HOST") | Some("BRIDGE") => true
+            case _                             => false
+          }
+        },
+        checkWarning("Singularity - Healthcheck", "No healthcheck defined") {
+          env.singularity.healthcheckUri.exists(_.trim.nonEmpty)
         }
-      },
-      checkWarning("Singularity - Healthcheck", "No healthcheck defined") {
-        env.singularity.healthcheckUri.exists(_.trim.nonEmpty)
-      })
-  } else {
-    Seq.empty
-  }
+      )
+    } else {
+      Seq.empty
+    }
 
-  def checkScheduledJob(env: Environment): Seq[Validation] = if (isScheduled(env)) {
+  def checkScheduledJob(env: Environment): Seq[Validation] =
+    if (isScheduled(env)) {
+      Seq(
+        check("Resources - Num Instances", "Must be = 0") {
+          env.resources.instances.isEmpty
+        },
+        check("Singularity - Job cron", "Missing") {
+          env.singularity.schedule.isDefined
+        }
+      )
+    } else {
+      Seq.empty
+    }
+
+  def checkContainer(container: Container): Seq[Validation] =
     Seq(
-      check("Resources - Num Instances", "Must be = 0") {
-        env.resources.instances.isEmpty
+      checkWarning("Container - Labels", "No labels defined") {
+        !container.labels.toSet.flatten.isEmpty
       },
-      check("Singularity - Job cron", "Missing") {
-        env.singularity.schedule.isDefined
-      })
-  } else {
-    Seq.empty
-  }
+      checkWarning("Container - Environment vars", "No env vars defined") {
+        !container.env_vars.toSet.flatten.isEmpty
+      }
+    )
 
-  def checkContainer(container: Container): Seq[Validation] = Seq(
-    checkWarning("Container - Labels", "No labels defined") {
-      !container.labels.toSet.flatten.isEmpty
-    },
-    checkWarning("Container - Environment vars", "No env vars defined") {
-      !container.env_vars.toSet.flatten.isEmpty
-    })
-
-  def checkDeprecated(file: java.io.File, today: LocalDate, gracePeriods: (Int, Int)): Seq[Validation] = {
+  def checkDeprecated(
+      file: java.io.File,
+      today: LocalDate,
+      gracePeriods: (Int, Int)
+  ): Seq[Validation] = {
     val f = scala.io.Source.fromFile(file)
-    val deprecated = f.getLines().filterNot(_.trim().startsWith("#")).filter(_.contains("@deprecated-on")).map(processLine)
+    val deprecated = f
+      .getLines()
+      .filterNot(_.trim().startsWith("#"))
+      .filter(_.contains("@deprecated-on"))
+      .map(processLine)
     deprecated.map(processDeprecated(_, today, gracePeriods)).toSeq
   }
 
   def isService(env: Environment) = {
-    (env.singularity.requestType.isEmpty && env.singularity.schedule.isEmpty) || env.singularity.requestType == Option("SERVICE")
+    (env.singularity.requestType.isEmpty && env.singularity.schedule.isEmpty) || env.singularity.requestType == Option(
+      "SERVICE"
+    )
   }
 
   def isScheduled(env: Environment) = {
-    (env.singularity.requestType.isEmpty && env.singularity.schedule.isDefined) || env.singularity.requestType == Option("SCHEDULED")
+    (env.singularity.requestType.isEmpty && env.singularity.schedule.isDefined) || env.singularity.requestType == Option(
+      "SCHEDULED"
+    )
   }
 
   // OLD_ENV_VAR_10: "old value" # @deprecated-on 10-Jan-2020
   def processLine(line: String): (String, LocalDate) = {
     val p = raw"^\s*([A-Z0-9_]+):.*# @deprecated-on (.*)".r
     val p(envVar, date) = line
-    val deprecatedOn = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+    val deprecatedOn =
+      LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
     (envVar, deprecatedOn)
   }
 
-  def processDeprecated(deprecated: (String, LocalDate), today: LocalDate, gracePeriods: (Int, Int)): Validation = {
+  def processDeprecated(
+      deprecated: (String, LocalDate),
+      today: LocalDate,
+      gracePeriods: (Int, Int)
+  ): Validation = {
     val (envVar, deprecatedOn) = deprecated
     val (deprecatedSoftGracePeriod, deprecatedHardGracePeriod) = gracePeriods
-    check(s"Deprecated Env Var - ${envVar}", s"< ${deprecatedHardGracePeriod}") {
-      jtt.ChronoUnit.DAYS.between(deprecatedOn, today) < deprecatedHardGracePeriod
+    check(
+      s"Deprecated Env Var - ${envVar}",
+      s"< ${deprecatedHardGracePeriod}"
+    ) {
+      jtt.ChronoUnit.DAYS
+        .between(deprecatedOn, today) < deprecatedHardGracePeriod
     } match {
       case Ok(_) =>
-        checkWarning(s"Deprecated Env Var - ${envVar}", s"< ${deprecatedSoftGracePeriod}") {
-          jtt.ChronoUnit.DAYS.between(deprecatedOn, today) < deprecatedSoftGracePeriod
+        checkWarning(
+          s"Deprecated Env Var - ${envVar}",
+          s"< ${deprecatedSoftGracePeriod}"
+        ) {
+          jtt.ChronoUnit.DAYS
+            .between(deprecatedOn, today) < deprecatedSoftGracePeriod
         }
       case error =>
         error
@@ -107,25 +146,35 @@ object Validations extends ValidationHelper {
 
 trait ValidationHelper {
 
-  def check(name: String, msg: String)(condition: => Boolean): Validation = if (condition) {
-    Ok(name)
-  } else {
-    Fail(name, msg)
-  }
+  def check(name: String, msg: String)(condition: => Boolean): Validation =
+    if (condition) {
+      Ok(name)
+    } else {
+      Fail(name, msg)
+    }
 
-  def checkWarning(name: String, msg: String)(condition: => Boolean): Validation = if (condition) {
-    Ok(name)
-  } else {
-    Warning(name, msg)
-  }
+  def checkWarning(name: String, msg: String)(
+      condition: => Boolean
+  ): Validation =
+    if (condition) {
+      Ok(name)
+    } else {
+      Warning(name, msg)
+    }
 
-  def logResult(checks: Seq[Validation], log: Logger) = checks.foreach {
-    case Ok(name) => log.println(s""" - ${log.infoColor("[OK]")}: $name""")
-    case Warning(name, msg) => log.println(s""" - ${log.errorColor("[Warning]")}: $name - $msg""")
-    case Fail(name, msg) => log.println(s""" - ${log.errorColor("[Failure]")}: $name - $msg""")
-  }
+  def logResult(checks: Seq[Validation], log: Logger) =
+    checks.foreach {
+      case Ok(name) => log.println(s""" - ${log.infoColor("[OK]")}: $name""")
+      case Warning(name, msg) =>
+        log.println(s""" - ${log.errorColor("[Warning]")}: $name - $msg""")
+      case Fail(name, msg) =>
+        log.println(s""" - ${log.errorColor("[Failure]")}: $name - $msg""")
+    }
 
-  def isValidPort(port: PortMap): Boolean = isValidPort(port.containerPort) && port.hostPort.map(isValidPort).getOrElse(true)
+  def isValidPort(port: PortMap): Boolean =
+    isValidPort(port.containerPort) && port.hostPort
+      .map(isValidPort)
+      .getOrElse(true)
 
   def isValidPort(port: Int): Boolean = 0 <= port && port <= 65535
 

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParser.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParser.scala
@@ -2,15 +2,15 @@ package com.nitro.nmesos.config
 
 import com.nitro.nmesos.config.YamlParserHelper._
 import com.nitro.nmesos.config.model._
-import com.nitro.nmesos.util.{ HashUtil, Logger }
+import com.nitro.nmesos.util.{HashUtil, Logger}
 import net.jcazevedo.moultingyaml._
 import org.yaml.snakeyaml.parser.ParserException
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
- * Yaml conf file to models
- */
+  * Yaml conf file to models
+  */
 object YamlParser {
 
   sealed trait ParserResult
@@ -20,41 +20,45 @@ object YamlParser {
   case class ValidYaml(config: Config, hash: String) extends ParserResult
 
   /**
-   * Try to parse a yaml.
-   */
-  def parse(sourceContent: String, logger: Logger): ParserResult = tryParse(sourceContent, logger) match {
+    * Try to parse a yaml.
+    */
+  def parse(sourceContent: String, logger: Logger): ParserResult =
+    tryParse(sourceContent, logger) match {
 
-    case Success(config) =>
-      ValidYaml(config, HashUtil.hash(sourceContent))
+      case Success(config) =>
+        ValidYaml(config, HashUtil.hash(sourceContent))
 
-    case Failure(ex: DeserializationException) =>
-      // Yaml data doesn't match our Case class, custom error message!
-      val field = ex.fieldNames.mkString("/")
-      InvalidYaml(s"Parser error for field $field: ${ex.msg}")
+      case Failure(ex: DeserializationException) =>
+        // Yaml data doesn't match our Case class, custom error message!
+        val field = ex.fieldNames.mkString("/")
+        InvalidYaml(s"Parser error for field $field: ${ex.msg}")
 
-    case Failure(ex: ParserException) =>
-      // Invalid Yaml here?
-      val line = ex.getProblemMark.getLine
-      val column = ex.getProblemMark.getColumn
-      val snippet = ex.getProblemMark.get_snippet
-      InvalidYaml(s"Invalid yaml file at line $line, column: $column\n$snippet")
+      case Failure(ex: ParserException) =>
+        // Invalid Yaml here?
+        val line = ex.getProblemMark.getLine
+        val column = ex.getProblemMark.getColumn
+        val snippet = ex.getProblemMark.get_snippet
+        InvalidYaml(
+          s"Invalid yaml file at line $line, column: $column\n$snippet"
+        )
 
-    case Failure(ex) =>
-      logger.debug(ex.getStackTrace.mkString("\n"))
-      InvalidYaml(s"Unexpected error: ${ex.getMessage}")
+      case Failure(ex) =>
+        logger.debug(ex.getStackTrace.mkString("\n"))
+        InvalidYaml(s"Unexpected error: ${ex.getMessage}")
 
-  }
+    }
 
   // Parse and merge default into environments.
-  private def tryParse(source: String, logger: Logger) = Try {
-    import YamlCustomProtocol._
-    val yaml = source.parseYaml
+  private def tryParse(source: String, logger: Logger) =
+    Try {
+      import YamlCustomProtocol._
+      val yaml = source.parseYaml
 
-    // Custom merge to extend Yaml merge
-    val smartYaml = mergeCommonsIntoEnvironments(yaml.asYamlObject)
-    logger.debug(s"Yaml evaluated content:\n ${smartYaml.prettyPrint}")
+      // Custom merge to extend Yaml merge
+      val smartYaml = mergeCommonsIntoEnvironments(yaml.asYamlObject)
+      logger.debug(s"Yaml evaluated content:\n ${smartYaml.prettyPrint}")
 
-    smartYaml.convertTo[Config]
-  }
+      smartYaml.convertTo[Config]
+    }
 
 }

--- a/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/YamlParserHelper.scala
@@ -1,18 +1,35 @@
 package com.nitro.nmesos.config
 
 import com.nitro.nmesos.config.model._
-import net.jcazevedo.moultingyaml.{ DefaultYamlProtocol, YamlArray, YamlBoolean, YamlDate, YamlFormat, YamlNull, YamlNumber, YamlObject, YamlSet, YamlString, YamlValue, deserializationError }
+import net.jcazevedo.moultingyaml.{
+  DefaultYamlProtocol,
+  YamlArray,
+  YamlBoolean,
+  YamlDate,
+  YamlFormat,
+  YamlNull,
+  YamlNumber,
+  YamlObject,
+  YamlSet,
+  YamlString,
+  YamlValue,
+  deserializationError
+}
 
 import scala.annotation.tailrec
 
 // Yaml parser Boilerplate
 object YamlParserHelper {
   def parsePortMap(portMap: String, protocols: Option[String]): PortMap = {
-    val (containerPort, hostPort) = portMap.split(":").map(_.toInt).toList match {
-      case containerPort :: Nil => (containerPort, None)
-      case containerPort :: hostPort :: Nil => (containerPort, Some(hostPort))
-      case _ => deserializationError("Failed to deserialize the port map specification")
-    }
+    val (containerPort, hostPort) =
+      portMap.split(":").map(_.toInt).toList match {
+        case containerPort :: Nil             => (containerPort, None)
+        case containerPort :: hostPort :: Nil => (containerPort, Some(hostPort))
+        case _ =>
+          deserializationError(
+            "Failed to deserialize the port map specification"
+          )
+      }
 
     PortMap(containerPort, hostPort, protocols)
   }
@@ -20,26 +37,37 @@ object YamlParserHelper {
   // boilerplate to parse our custom case class
   object YamlCustomProtocol extends DefaultYamlProtocol {
     implicit val PortMapYamlFormat = new YamlFormat[PortMap] {
-      override def read(yaml: YamlValue): PortMap = yaml match {
-        case YamlNumber(_) => PortMap(yaml.convertTo[Int], None, None)
-        case YamlString(_) => yaml.convertTo[String].split("/").toList match {
-          case portMap :: Nil => parsePortMap(portMap, None)
-          case portMap :: protocols :: Nil => parsePortMap(portMap, Option(protocols))
-          case _ => deserializationError("Failed to deserialize the port map specification")
+      override def read(yaml: YamlValue): PortMap =
+        yaml match {
+          case YamlNumber(_) => PortMap(yaml.convertTo[Int], None, None)
+          case YamlString(_) =>
+            yaml.convertTo[String].split("/").toList match {
+              case portMap :: Nil => parsePortMap(portMap, None)
+              case portMap :: protocols :: Nil =>
+                parsePortMap(portMap, Option(protocols))
+              case _ =>
+                deserializationError(
+                  "Failed to deserialize the port map specification"
+                )
+            }
+          case _ =>
+            deserializationError("Failed to deserialize the port specification")
         }
-        case _ => deserializationError("Failed to deserialize the port specification")
-      }
 
       override def write(portMap: PortMap): YamlValue = {
         portMap.protocols match {
-          case None => portMap.hostPort match {
-            case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}")
-            case None => YamlNumber(portMap.containerPort)
-          }
-          case Some(protocols) => portMap.hostPort match {
-            case Some(hostPort) => YamlString(s"${portMap.containerPort}:${hostPort}/${protocols}")
-            case None => YamlString(s"${portMap.containerPort}/${protocols}")
-          }
+          case None =>
+            portMap.hostPort match {
+              case Some(hostPort) =>
+                YamlString(s"${portMap.containerPort}:${hostPort}")
+              case None => YamlNumber(portMap.containerPort)
+            }
+          case Some(protocols) =>
+            portMap.hostPort match {
+              case Some(hostPort) =>
+                YamlString(s"${portMap.containerPort}:${hostPort}/${protocols}")
+              case None => YamlString(s"${portMap.containerPort}/${protocols}")
+            }
         }
       }
     }
@@ -55,32 +83,32 @@ object YamlParserHelper {
   }
 
   /**
-   * Custom merge from Commons into Environments.
-   * The Standard Yaml Merge is only a hash one level merge, implementing a smarter deep merge here.
-   * -> input example:
-   * common:
-   *   version: 1
-   *   resources:
-   *   cpus: 1
-   *
-   * environments:
-   *   dev:
-   *   resources:
-   *   mem: 1024
-   *
-   * -> out example:
-   * environments:
-   *   dev:
-   *     version: 1
-   *     resources:
-   *     cpus: 1
-   *     mem: 1024
-   *
-   */
+    * Custom merge from Commons into Environments.
+    * The Standard Yaml Merge is only a hash one level merge, implementing a smarter deep merge here.
+    * -> input example:
+    * common:
+    *   version: 1
+    *   resources:
+    *   cpus: 1
+    *
+    * environments:
+    *   dev:
+    *   resources:
+    *   mem: 1024
+    *
+    * -> out example:
+    * environments:
+    *   dev:
+    *     version: 1
+    *     resources:
+    *     cpus: 1
+    *     mem: 1024
+    */
   def mergeCommonsIntoEnvironments(yaml: YamlObject): YamlObject = {
     val commonKey = YamlString("common")
     val common = yaml.fields(commonKey).asYamlObject
-    val environments: Map[YamlValue, YamlValue] = yaml.fields(YamlString("environments")).asYamlObject.fields
+    val environments: Map[YamlValue, YamlValue] =
+      yaml.fields(YamlString("environments")).asYamlObject.fields
 
     // Add environments fields recursively
     val updatedEnvironments = environments.mapValues { environment =>
@@ -88,11 +116,16 @@ object YamlParserHelper {
     }
 
     // return new Yaml with commons and environments joined
-    val updatedFields = yaml.fields.filterKeys(_ != commonKey) + (YamlString("environments") -> new YamlObject(updatedEnvironments))
+    val updatedFields = yaml.fields.filterKeys(_ != commonKey) + (YamlString(
+      "environments"
+    ) -> new YamlObject(updatedEnvironments))
     new YamlObject(updatedFields)
   }
 
-  private def smartMerge(initialFields: Map[YamlValue, YamlValue], element: YamlObject): YamlObject = {
+  private def smartMerge(
+      initialFields: Map[YamlValue, YamlValue],
+      element: YamlObject
+  ): YamlObject = {
     val fields = element.fields.foldLeft(initialFields) {
       case (mergedFields, (key, value)) =>
         if (!mergedFields.contains(key) || mergedFields(key) == YamlNull) {
@@ -102,13 +135,18 @@ object YamlParserHelper {
           value match {
             case yamlObject: YamlObject =>
               val previousObjectField = mergedFields(key).asYamlObject.fields
-              mergedFields + (key -> smartMerge(previousObjectField, yamlObject))
+              mergedFields + (key -> smartMerge(
+                previousObjectField,
+                yamlObject
+              ))
 
-            case YamlNull | YamlBoolean(_) | YamlDate(_) | YamlNumber(_) | YamlString(_) =>
+            case YamlNull | YamlBoolean(_) | YamlDate(_) | YamlNumber(_) |
+                YamlString(_) =>
               mergedFields + (key -> value)
 
             case YamlArray(values) =>
-              val previousArray = mergedFields(key).asInstanceOf[YamlArray].elements
+              val previousArray =
+                mergedFields(key).asInstanceOf[YamlArray].elements
               val distinctValues = Set((values ++ previousArray): _*)
               mergedFields + (key -> YamlArray(distinctValues.toVector))
 

--- a/shared/src/main/scala/com/nitro/nmesos/config/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/model.scala
@@ -1,78 +1,85 @@
 package com.nitro.nmesos.config
 
 /**
- * Yaml file model.
- * ConfigReader.parse(file) load a file into this model.
- */
+  * Yaml file model.
+  * ConfigReader.parse(file) load a file into this model.
+  */
 object model {
 
   type EnvironmentName = String
 
   case class CmdConfig(
-    serviceName: String,
-    tag: String,
-    force: Boolean,
-    environmentName: EnvironmentName,
-    environment: Environment,
-    fileHash: String,
-    file: java.io.File)
+      serviceName: String,
+      tag: String,
+      force: Boolean,
+      environmentName: EnvironmentName,
+      environment: Environment,
+      fileHash: String,
+      file: java.io.File
+  )
 
   case class Config(
-    nmesos_version: String,
-    environments: Map[EnvironmentName, Environment])
+      nmesos_version: String,
+      environments: Map[EnvironmentName, Environment]
+  )
 
   case class Environment(
-    resources: Resources,
-    container: Container,
-    executor: Option[ExecutorConf],
-    singularity: SingularityConf,
-    after_deploy: Option[AfterDeployConf])
+      resources: Resources,
+      container: Container,
+      executor: Option[ExecutorConf],
+      singularity: SingularityConf,
+      after_deploy: Option[AfterDeployConf]
+  )
 
-  case class Resources(
-    cpus: Double,
-    memoryMb: Int,
-    instances: Option[Int])
+  case class Resources(cpus: Double, memoryMb: Int, instances: Option[Int])
 
   case class PortMap(
-    containerPort: Int,
-    hostPort: Option[Int],
-    protocols: Option[String])
+      containerPort: Int,
+      hostPort: Option[Int],
+      protocols: Option[String]
+  )
 
   case class Container(
-    image: String,
-    command: Option[String],
-    forcePullImage: Option[Boolean],
-    ports: Option[Seq[PortMap]],
-    labels: Option[Map[String, String]],
-    env_vars: Option[Map[String, String]],
-    volumes: Option[Seq[String]],
-    network: Option[String],
-    dockerParameters: Option[Map[String, String]],
-    deploy_freeze: Option[Boolean])
+      image: String,
+      command: Option[String],
+      forcePullImage: Option[Boolean],
+      ports: Option[Seq[PortMap]],
+      labels: Option[Map[String, String]],
+      env_vars: Option[Map[String, String]],
+      volumes: Option[Seq[String]],
+      network: Option[String],
+      dockerParameters: Option[Map[String, String]],
+      deploy_freeze: Option[Boolean]
+  )
 
   case class SingularityConf(
-    url: String,
-    schedule: Option[String],
-    requestType: Option[String],
-    deployInstanceCountPerStep: Option[Int],
-    deployStepWaitTimeMs: Option[Int],
-    deployHealthTimeoutSeconds: Option[Int],
-    autoAdvanceDeploySteps: Option[Boolean],
-    healthcheckUri: Option[String],
-    healthcheckPortIndex: Option[Int],
-    healthcheckMaxRetries: Option[Int],
-    healthcheckTimeoutSeconds: Option[Int],
-    healthcheckMaxTotalTimeoutSeconds: Option[Int],
-    requiredRole: Option[String],
-    requiredAttributes: Option[Map[String, String]],
-    allowedSlaveAttributes: Option[Map[String, String]],
-    slavePlacement: Option[String])
+      url: String,
+      schedule: Option[String],
+      requestType: Option[String],
+      deployInstanceCountPerStep: Option[Int],
+      deployStepWaitTimeMs: Option[Int],
+      deployHealthTimeoutSeconds: Option[Int],
+      autoAdvanceDeploySteps: Option[Boolean],
+      healthcheckUri: Option[String],
+      healthcheckPortIndex: Option[Int],
+      healthcheckMaxRetries: Option[Int],
+      healthcheckTimeoutSeconds: Option[Int],
+      healthcheckMaxTotalTimeoutSeconds: Option[Int],
+      requiredRole: Option[String],
+      requiredAttributes: Option[Map[String, String]],
+      allowedSlaveAttributes: Option[Map[String, String]],
+      slavePlacement: Option[String]
+  )
 
   case class ExecutorConf(
-    customExecutorCmd: Option[String],
-    env_vars: Option[Map[String, String]])
+      customExecutorCmd: Option[String],
+      env_vars: Option[Map[String, String]]
+  )
 
-  case class AfterDeployConf(on_success: List[DeployJob], on_failure: Option[DeployJob])
+  case class AfterDeployConf(
+      on_success: List[DeployJob],
+      on_failure: Option[DeployJob]
+  )
 
   case class DeployJob(service_name: String, tag: Option[String])
 }

--- a/shared/src/main/scala/com/nitro/nmesos/docker/SshDockerClient.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/docker/SshDockerClient.scala
@@ -7,13 +7,13 @@ import scala.language.postfixOps
 import sys.process._
 
 /**
- * Run Remote Docker commands through ssh to inspect the containers running.
- */
+  * Run Remote Docker commands through ssh to inspect the containers running.
+  */
 object SshDockerClient {
 
   /**
-   * Docker ps and inspect all containers in the host.
-   */
+    * Docker ps and inspect all containers in the host.
+    */
   def fetchContainers(host: String): Seq[Container] = {
     val containers = parseOutput(dockerPs(host), host)
     fetchContainersEnv(host, containers)
@@ -27,25 +27,34 @@ object SshDockerClient {
   // Docker inspect
   // Fetch labels and environments var
   private def dockerInspectEnv(host: String, containersId: Seq[String]) = {
-    s"""ssh -oStrictHostKeyChecking=no $host docker inspect ${containersId.mkString(" ")} --format '{{range .Config.Env }}{{ $$.ID}}:{{.}}~{{end}}~{{range  $$key, $$value := .Config.Labels}}{{ $$.ID}}:{{$$key}}={{$$value}}~{{end}}' """ !!
+    s"""ssh -oStrictHostKeyChecking=no $host docker inspect ${containersId
+      .mkString(
+        " "
+      )} --format '{{range .Config.Env }}{{ $$.ID}}:{{.}}~{{end}}~{{range  $$key, $$value := .Config.Labels}}{{ $$.ID}}:{{$$key}}={{$$value}}~{{end}}' """ !!
   }
 
   /**
-   * For each container fetch the environment vars
-   */
-  private def fetchContainersEnv(host: String, containers: Seq[Container]): Seq[Container] = {
+    * For each container fetch the environment vars
+    */
+  private def fetchContainersEnv(
+      host: String,
+      containers: Seq[Container]
+  ): Seq[Container] = {
 
     val output = dockerInspectEnv(host, containers.map(_.id))
 
     val lines = output.trim
       .split("\n|~")
 
-    val linesByContainer = lines.filterNot(_.isEmpty)
+    val linesByContainer = lines
+      .filterNot(_.isEmpty)
       .groupBy(_.takeWhile(_ != ':').take(12)) // Group by short Container Id
       .mapValues(_.map(_.dropWhile(_ != ':').drop(1))) // raw env vars as value
 
     val envByContainer = linesByContainer.mapValues { lines =>
-      lines.map(_.split("=", 2) match { case Array(key, value) => (key, value) }).toMap
+      lines
+        .map(_.split("=", 2) match { case Array(key, value) => (key, value) })
+        .toMap
     }
 
     containers.map { c =>
@@ -55,7 +64,10 @@ object SshDockerClient {
   }
 
   private def parseTaskId(inspectOutput: String) = {
-    inspectOutput.split(" ").find(_.startsWith("TASK_ID=")).map(_.dropWhile(_ != '=').drop(1))
+    inspectOutput
+      .split(" ")
+      .find(_.startsWith("TASK_ID="))
+      .map(_.dropWhile(_ != '=').drop(1))
   }
 
   private def parseOutput(psOutput: String, host: String): Seq[Container] = {
@@ -63,9 +75,9 @@ object SshDockerClient {
       .split("\n")
       .map(_.split("\t").toList)
       .map {
-        case (id :: image :: name :: Nil) => Container(id, image, name, host, Map.empty)
-        case _ => sys.error(
-          s"""Unable to parse Docker output:
+        case (id :: image :: name :: Nil) =>
+          Container(id, image, name, host, Map.empty)
+        case _ => sys.error(s"""Unable to parse Docker output:
              |$psOutput
           """.stripMargin)
       }

--- a/shared/src/main/scala/com/nitro/nmesos/docker/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/docker/model.scala
@@ -2,7 +2,13 @@ package com.nitro.nmesos.docker
 
 object model {
 
-  case class Container(id: String, image: String, name: String, host: String, env: Map[String, String]) {
+  case class Container(
+      id: String,
+      image: String,
+      name: String,
+      host: String,
+      env: Map[String, String]
+  ) {
 
     def envTaskId = env.get("TASK_ID")
 

--- a/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarManager.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarManager.scala
@@ -1,10 +1,19 @@
 package com.nitro.nmesos.sidecar
 
-import com.nitro.nmesos.util.{ HttpClientHelper, Logger }
+import com.nitro.nmesos.util.{HttpClientHelper, Logger}
 
-case class Service(ID: String, Name: String, Status: Int, Hostname: String, Image: String)
+case class Service(
+    ID: String,
+    Name: String,
+    Status: Int,
+    Hostname: String,
+    Image: String
+)
 
-case class SidecarServices(Services: Map[String, Seq[Service]], hostName: String = "")
+case class SidecarServices(
+    Services: Map[String, Seq[Service]],
+    hostName: String = ""
+)
 
 case class SidecarManager(log: Logger) extends HttpClientHelper {
 

--- a/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarUtils.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/sidecar/SidecarUtils.scala
@@ -4,57 +4,92 @@ import com.nitro.nmesos.docker.model.Container
 import com.nitro.nmesos.singularity.model.SingularityRequestParent
 import com.nitro.nmesos.util.Logger
 
-case class EnvironmentInfo(requests: Seq[SingularityRequestParent], containers: Seq[Container], sidecarsServices: Seq[SidecarServices])
+case class EnvironmentInfo(
+    requests: Seq[SingularityRequestParent],
+    containers: Seq[Container],
+    sidecarsServices: Seq[SidecarServices]
+)
 
 object SidecarUtils {
 
   /**
-   * Verify all the Sidecar state are in-sync across all the servers running in the cluster.
-   * @param info
-   * @return
-   */
+    * Verify all the Sidecar state are in-sync across all the servers running in the cluster.
+    * @param info
+    * @return
+    */
   def verifyInSync(info: EnvironmentInfo)(implicit log: Logger): Boolean = {
-    info.sidecarsServices.sliding(2).map {
-      case Seq(sidecarA, sidecarB) =>
-        val diff = sidecarA.Services.values.toSeq.flatten.sortBy(_.ID).diff(sidecarB.Services.values.toSeq.flatten.sortBy(_.ID))
-        if (diff.nonEmpty) {
+    info.sidecarsServices
+      .sliding(2)
+      .map {
+        case Seq(sidecarA, sidecarB) =>
+          val diff = sidecarA.Services.values.toSeq.flatten
+            .sortBy(_.ID)
+            .diff(sidecarB.Services.values.toSeq.flatten.sortBy(_.ID))
+          if (diff.nonEmpty) {
 
-          log.println(s""" ${log.Fail} Sidecar is not in sync at ${sidecarB.hostName} for services ${diff.map(_.Name).mkString(",")}""")
-        } else {
-          log.println(s""" ${log.Ok} Sidecar running at ${sidecarA.hostName} in sync with ${sidecarB.hostName} """)
-        }
-        diff.isEmpty
-    }.reduce(_ && _)
+            log.println(
+              s""" ${log.Fail} Sidecar is not in sync at ${sidecarB.hostName} for services ${diff
+                .map(_.Name)
+                .mkString(",")}"""
+            )
+          } else {
+            log.println(
+              s""" ${log.Ok} Sidecar running at ${sidecarA.hostName} in sync with ${sidecarB.hostName} """
+            )
+          }
+          diff.isEmpty
+      }
+      .reduce(_ && _)
   }
 
   /**
-   * Verify the containers (integrated with Sidecar) and Sidecar state is in sync.
-   */
+    * Verify the containers (integrated with Sidecar) and Sidecar state is in sync.
+    */
   def verifyServices(info: EnvironmentInfo)(implicit log: Logger): Boolean = {
     // fetch all Containers where SidecarDiscover!=false
     val containersByServiceName = info.containers
-      .filter(!_.env.exists { case (key, value) => key == "SidecarDiscover" && value == "false" })
-      .groupBy(_.env.find { case (key, _) => key == "ServiceName" }.map(_._2).getOrElse("")) // group by serviceName
+      .filter(!_.env.exists {
+        case (key, value) => key == "SidecarDiscover" && value == "false"
+      })
+      .groupBy(
+        _.env
+          .find { case (key, _) => key == "ServiceName" }
+          .map(_._2)
+          .getOrElse("")
+      ) // group by serviceName
 
     // Fetch Sidecar info about by Service
     val sidecarByServiceName = info.sidecarsServices.head.Services
 
     // Compare containers and service info
-    sidecarByServiceName.map {
-      case (serviceName, sidecarEntries) =>
-        val containerInfo = containersByServiceName.get(serviceName).getOrElse(Seq.empty)
-          .map(c => s"${c.image} @ ${c.host}").sorted
+    sidecarByServiceName
+      .map {
+        case (serviceName, sidecarEntries) =>
+          val containerInfo = containersByServiceName
+            .get(serviceName)
+            .getOrElse(Seq.empty)
+            .map(c => s"${c.image} @ ${c.host}")
+            .sorted
 
-        val sidecarInfo = sidecarEntries.filter(_.Status == 0)
-          .map { s => s"${s.Image} @ ${s.Hostname}" }.sorted
+          val sidecarInfo = sidecarEntries
+            .filter(_.Status == 0)
+            .map { s => s"${s.Image} @ ${s.Hostname}" }
+            .sorted
 
-        diffInfo(containerInfo, sidecarInfo, serviceName)
-    }.reduce(_ && _)
+          diffInfo(containerInfo, sidecarInfo, serviceName)
+      }
+      .reduce(_ && _)
   }
 
-  def diffInfo(containerInfo: Seq[String], sidecarInfo: Seq[String], serviceName: String)(implicit log: Logger): Boolean = {
+  def diffInfo(
+      containerInfo: Seq[String],
+      sidecarInfo: Seq[String],
+      serviceName: String
+  )(implicit log: Logger): Boolean = {
     if (containerInfo.sameElements(sidecarInfo)) {
-      log.println(s""" ${log.Ok} Sidecar mapping for $serviceName match all containers running """)
+      log.println(
+        s""" ${log.Ok} Sidecar mapping for $serviceName match all containers running """
+      )
       sidecarInfo.foreach { info =>
         log.info(s"\t\t$info")
       }

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/ModelConversions.scala
@@ -1,44 +1,57 @@
 package com.nitro.nmesos.singularity
 
-import com.nitro.nmesos.config.model.{ CmdConfig, Environment, PortMap }
+import com.nitro.nmesos.config.model.{CmdConfig, Environment, PortMap}
 import com.nitro.nmesos.singularity.model._
 import com.nitro.nmesos.util.SequenceUtil
 import org.joda.time.DateTime
 
 /**
- * Conversion from local config models to Singularity Models.
- */
+  * Conversion from local config models to Singularity Models.
+  */
 object ModelConversions {
 
-  def toSingularityResources(environment: Environment) = SingularityResources(
-    cpus = environment.resources.cpus,
-    memoryMb = environment.resources.memoryMb,
-    numPorts = environment.container.ports.map(_.size).getOrElse(0),
-    diskMb = 0)
+  def toSingularityResources(environment: Environment) =
+    SingularityResources(
+      cpus = environment.resources.cpus,
+      memoryMb = environment.resources.memoryMb,
+      numPorts = environment.container.ports.map(_.size).getOrElse(0),
+      diskMb = 0
+    )
 
   def imageWithTag(config: CmdConfig): String = {
     val tag = if (config.tag.isEmpty) "latest" else config.tag
     s"${config.environment.container.image}:${tag}"
   }
 
-  def getSingularityPortMapping(containerPort: Int, hostPort: Option[Int], protocol: String, index: Int) = {
+  def getSingularityPortMapping(
+      containerPort: Int,
+      hostPort: Option[Int],
+      protocol: String,
+      index: Int
+  ) = {
     hostPort match {
-      case Some(hostPort) => SingularityDockerPortMapping(
-        containerPort = containerPort,
-        containerPortType = "LITERAL",
-        hostPort = hostPort,
-        hostPortType = "LITERAL",
-        protocol = protocol)
-      case None => SingularityDockerPortMapping(
-        containerPort = containerPort,
-        containerPortType = "LITERAL",
-        hostPort = index, // When using Literal Host (PORT0, PORT1, PORT2)
-        hostPortType = "FROM_OFFER",
-        protocol = protocol)
+      case Some(hostPort) =>
+        SingularityDockerPortMapping(
+          containerPort = containerPort,
+          containerPortType = "LITERAL",
+          hostPort = hostPort,
+          hostPortType = "LITERAL",
+          protocol = protocol
+        )
+      case None =>
+        SingularityDockerPortMapping(
+          containerPort = containerPort,
+          containerPortType = "LITERAL",
+          hostPort = index, // When using Literal Host (PORT0, PORT1, PORT2)
+          hostPortType = "FROM_OFFER",
+          protocol = protocol
+        )
     }
   }
 
-  def toSingularityContainerInfo(config: CmdConfig): SingularityContainerInfo = {
+  def toSingularityContainerInfo(
+      config: CmdConfig
+  ): SingularityContainerInfo = {
     val network = config.environment.container.network.getOrElse("BRIDGE")
     val containerPorts = config.environment.container.ports.getOrElse(Seq.empty)
 
@@ -47,31 +60,56 @@ object ModelConversions {
     }
 
     val portMappings = containerPorts.zipWithIndex.map {
-      case (portMap, index) => if (portMap.protocols.isEmpty) {
-        // Default to using TCP
-        getSingularityPortMapping(portMap.containerPort, portMap.hostPort, "tcp", index)
-      } else {
-        getSingularityPortMapping(portMap.containerPort, portMap.hostPort, portMap.protocols.mkString(","), index)
-      }
+      case (portMap, index) =>
+        if (portMap.protocols.isEmpty) {
+          // Default to using TCP
+          getSingularityPortMapping(
+            portMap.containerPort,
+            portMap.hostPort,
+            "tcp",
+            index
+          )
+        } else {
+          getSingularityPortMapping(
+            portMap.containerPort,
+            portMap.hostPort,
+            portMap.protocols.mkString(","),
+            index
+          )
+        }
     }
 
     val labels = config.environment.container.labels
-      .getOrElse(Map.empty).map { case (key, value) => SingularityDockerParameter("label", s"$key=$value") }.toSeq
+      .getOrElse(Map.empty)
+      .map {
+        case (key, value) => SingularityDockerParameter("label", s"$key=$value")
+      }
+      .toSeq
 
     val envVars = config.environment.container.env_vars
-      .getOrElse(Map.empty).map { case (key, value) => SingularityDockerParameter("env", s"$key=$value") }.toSeq
+      .getOrElse(Map.empty)
+      .map {
+        case (key, value) => SingularityDockerParameter("env", s"$key=$value")
+      }
+      .toSeq
 
-    val extraDockerParameters = config.environment.container.dockerParameters.getOrElse(Map.empty)
-      .map { case (key, value) => SingularityDockerParameter(key, value) }.toSeq
+    val extraDockerParameters = config.environment.container.dockerParameters
+      .getOrElse(Map.empty)
+      .map { case (key, value) => SingularityDockerParameter(key, value) }
+      .toSeq
 
     val dockerParameters = labels ++ envVars ++ extraDockerParameters
 
-    val volumes = config.environment.container.volumes.getOrElse(Seq.empty).map { volumenMapping =>
-      volumenMapping.split(":").toSeq match {
-        case Seq(hostPath, containerPath) => SingularityVolume(hostPath, containerPath, "RW")
-        case Seq(hostPath, containerPath, mode) => SingularityVolume(hostPath, containerPath, mode)
+    val volumes =
+      config.environment.container.volumes.getOrElse(Seq.empty).map {
+        volumenMapping =>
+          volumenMapping.split(":").toSeq match {
+            case Seq(hostPath, containerPath) =>
+              SingularityVolume(hostPath, containerPath, "RW")
+            case Seq(hostPath, containerPath, mode) =>
+              SingularityVolume(hostPath, containerPath, mode)
+          }
       }
-    }
 
     SingularityContainerInfo(
       `type` = "DOCKER",
@@ -80,13 +118,16 @@ object ModelConversions {
         network = network,
         image = imageWithTag(config),
         portMappings = portMappings,
-        forcePullImage = config.environment.container.forcePullImage.getOrElse(false),
-        dockerParameters = dockerParameters))
+        forcePullImage =
+          config.environment.container.forcePullImage.getOrElse(false),
+        dockerParameters = dockerParameters
+      )
+    )
   }
 
   /**
-   * Singularity Id can contain only "a-zA-Z0-9"
-   */
+    * Singularity Id can contain only "a-zA-Z0-9"
+    */
   def normalizeId(id: String): String = {
     id.replaceAll("[^a-zA-Z0-9]", "_")
   }
@@ -110,50 +151,71 @@ object ModelConversions {
   type DeployId = String
 
   /**
-   * Deploy Id used if there are no collisions.
-   */
+    * Deploy Id used if there are no collisions.
+    */
   def defaultDeployId(config: CmdConfig): DeployId = {
     normalizeId(s"${config.tag}-${config.fileHash}")
   }
 
   /**
-   * Deploy Id used if there are collisions
-   */
+    * Deploy Id used if there are collisions
+    */
   def generateRandomDeployId(defaultId: DeployId): DeployId = {
     val sequence = SequenceUtil.sequenceId()
     normalizeId(s"${defaultId}-$sequence")
   }
 
-  def toSingularityDeploy(config: CmdConfig, deployId: DeployId) = SingularityDeploy(
-    requestId = toSingularityRequestId(config),
-    id = deployId,
-    resources = toSingularityResources(config.environment),
-    containerInfo = toSingularityContainerInfo(config),
-    healthcheckUri = config.environment.singularity.healthcheckUri,
-    healthcheckPortIndex = config.environment.singularity.healthcheckPortIndex,
-    healthcheckMaxRetries = config.environment.singularity.healthcheckMaxRetries,
-    healthcheckTimeoutSeconds = config.environment.singularity.healthcheckTimeoutSeconds,
-    healthcheckMaxTotalTimeoutSeconds = config.environment.singularity.healthcheckMaxTotalTimeoutSeconds,
-    deployInstanceCountPerStep = config.environment.singularity.deployInstanceCountPerStep,
-    deployStepWaitTimeMs = config.environment.singularity.deployStepWaitTimeMs,
-    deployHealthTimeoutSeconds = config.environment.singularity.deployHealthTimeoutSeconds,
-    customExecutorCmd = config.environment.executor.flatMap(_.customExecutorCmd),
-    env = config.environment.executor.flatMap(_.env_vars).getOrElse(Map.empty),
-    autoAdvanceDeploySteps = config.environment.singularity.autoAdvanceDeploySteps,
-    command = config.environment.container.command,
-    shell = config.environment.container.command.map(_ => true))
+  def toSingularityDeploy(config: CmdConfig, deployId: DeployId) =
+    SingularityDeploy(
+      requestId = toSingularityRequestId(config),
+      id = deployId,
+      resources = toSingularityResources(config.environment),
+      containerInfo = toSingularityContainerInfo(config),
+      healthcheckUri = config.environment.singularity.healthcheckUri,
+      healthcheckPortIndex =
+        config.environment.singularity.healthcheckPortIndex,
+      healthcheckMaxRetries =
+        config.environment.singularity.healthcheckMaxRetries,
+      healthcheckTimeoutSeconds =
+        config.environment.singularity.healthcheckTimeoutSeconds,
+      healthcheckMaxTotalTimeoutSeconds =
+        config.environment.singularity.healthcheckMaxTotalTimeoutSeconds,
+      deployInstanceCountPerStep =
+        config.environment.singularity.deployInstanceCountPerStep,
+      deployStepWaitTimeMs =
+        config.environment.singularity.deployStepWaitTimeMs,
+      deployHealthTimeoutSeconds =
+        config.environment.singularity.deployHealthTimeoutSeconds,
+      customExecutorCmd =
+        config.environment.executor.flatMap(_.customExecutorCmd),
+      env =
+        config.environment.executor.flatMap(_.env_vars).getOrElse(Map.empty),
+      autoAdvanceDeploySteps =
+        config.environment.singularity.autoAdvanceDeploySteps,
+      command = config.environment.container.command,
+      shell = config.environment.container.command.map(_ => true)
+    )
 
-  def toSingularityRequest(config: CmdConfig) = SingularityRequest(
-    id = toSingularityRequestId(config),
-    requestType = toRequestType(config),
-    instances = config.environment.resources.instances,
-    slavePlacement = config.environment.singularity.slavePlacement.getOrElse("OPTIMISTIC"),
-    schedule = config.environment.singularity.schedule,
-    requiredSlaveAttributes = config.environment.singularity.requiredAttributes.getOrElse(Map.empty),
-    allowedSlaveAttributes = config.environment.singularity.allowedSlaveAttributes.getOrElse(Map.empty),
-    requiredRole = config.environment.singularity.requiredRole)
+  def toSingularityRequest(config: CmdConfig) =
+    SingularityRequest(
+      id = toSingularityRequestId(config),
+      requestType = toRequestType(config),
+      instances = config.environment.resources.instances,
+      slavePlacement =
+        config.environment.singularity.slavePlacement.getOrElse("OPTIMISTIC"),
+      schedule = config.environment.singularity.schedule,
+      requiredSlaveAttributes =
+        config.environment.singularity.requiredAttributes.getOrElse(Map.empty),
+      allowedSlaveAttributes =
+        config.environment.singularity.allowedSlaveAttributes
+          .getOrElse(Map.empty),
+      requiredRole = config.environment.singularity.requiredRole
+    )
 
-  def describeDeploy(request: SingularityRequest, deploy: SingularityDeploy): Seq[String] = {
+  def describeDeploy(
+      request: SingularityRequest,
+      deploy: SingularityDeploy
+  ): Seq[String] = {
     val common = Seq(
       s"requestId: ${request.id}",
       s"deployId:  ${deploy.id}",
@@ -162,15 +224,22 @@ object ModelConversions {
          | cpus: ${deploy.resources.cpus}
          | memory: ${deploy.resources.memoryMb}Mb
          | role: ${request.requiredRole.getOrElse("*")}
-         | required slave attributes: ${request.requiredSlaveAttributes.mkString(",")}
-         | allowed slave attributes: ${request.allowedSlaveAttributes.mkString(",")}
-         |""".stripMargin)
+         | required slave attributes: ${request.requiredSlaveAttributes
+        .mkString(",")}
+         | allowed slave attributes: ${request.allowedSlaveAttributes.mkString(
+        ","
+      )}
+         |""".stripMargin
+    )
     if (request.schedule.isDefined) {
       common ++ request.schedule.map(cron => s"scheduled: $cron").toSeq
     } else {
       common ++ Seq(
         s"instances: ${request.instances.getOrElse("*")}, slavePlacement: ${request.slavePlacement}",
-        s"""ports:     ${deploy.containerInfo.docker.portMappings.map(_.containerPort).mkString(",")}""".trim)
+        s"""ports:     ${deploy.containerInfo.docker.portMappings
+          .map(_.containerPort)
+          .mkString(",")}""".trim
+      )
     }
   }.sorted
 

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/SingularityManager.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/SingularityManager.scala
@@ -3,62 +3,95 @@ package com.nitro.nmesos.singularity
 import com.nitro.nmesos.config.model.SingularityConf
 import com.nitro.nmesos.singularity.ModelConversions.DeployId
 import com.nitro.nmesos.singularity.model._
-import com.nitro.nmesos.util.{ HttpClientHelper, InfoLogger, Logger }
-import scala.util.{ Success, Try }
+import com.nitro.nmesos.util.{HttpClientHelper, InfoLogger, Logger}
+import scala.util.{Success, Try}
 import com.nitro.nmesos.util.Conversions._
+
 /**
- * Can build Dryrun (readonly) or Real Singularity Manager (read-write).
- */
+  * Can build Dryrun (readonly) or Real Singularity Manager (read-write).
+  */
 object SingularityManager {
-  def apply(conf: SingularityConf, log: Logger, isDryrun: Boolean): SingularityManager = if (isDryrun) {
-    DryrunSingularityManager(conf.url, log)
-  } else {
-    RealSingularityManager(conf, log)
-  }
+  def apply(
+      conf: SingularityConf,
+      log: Logger,
+      isDryrun: Boolean
+  ): SingularityManager =
+    if (isDryrun) {
+      DryrunSingularityManager(conf.url, log)
+    } else {
+      RealSingularityManager(conf, log)
+    }
 }
 
 trait SingularityManager extends HttpClientHelper {
   val apiUrl: String
   import com.nitro.nmesos.util.CustomPicklers.OptionPickler._
 
-  def createSingularityRequest(newRequest: SingularityRequest): Try[SingularityRequestParent]
+  def createSingularityRequest(
+      newRequest: SingularityRequest
+  ): Try[SingularityRequestParent]
 
-  def scaleSingularityRequest(previous: SingularityRequest, request: SingularityRequest): Try[SingularityUpdateResult]
+  def scaleSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ): Try[SingularityUpdateResult]
 
-  def updateSingularityRequest(previous: SingularityRequest, request: SingularityRequest): Try[SingularityUpdateResult]
+  def updateSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ): Try[SingularityUpdateResult]
 
-  def deploySingularityDeploy(currentRequest: SingularityRequest, newDeploy: SingularityDeploy, message: String): Try[SingularityRequestParent]
+  def deploySingularityDeploy(
+      currentRequest: SingularityRequest,
+      newDeploy: SingularityDeploy,
+      message: String
+  ): Try[SingularityRequestParent]
 
   def ping(): Try[Unit] = {
     get[Unit](s"$apiUrl/api/requests").map(_.getOrElse(()))
   }
 
-  def getSingularityRequest(requestId: String): Try[Option[SingularityRequestParent]] = {
+  def getSingularityRequest(
+      requestId: String
+  ): Try[Option[SingularityRequestParent]] = {
     get[SingularityRequestParent](s"$apiUrl/api/requests/request/$requestId")
   }
 
-  def getSingularityDeployHistory(requestId: String, deployId: DeployId): Try[Option[SingularityDeployHistory]] = {
-    get[SingularityDeployHistory](s"$apiUrl/api/history/request/$requestId/deploy/$deployId")
+  def getSingularityDeployHistory(
+      requestId: String,
+      deployId: DeployId
+  ): Try[Option[SingularityDeployHistory]] = {
+    get[SingularityDeployHistory](
+      s"$apiUrl/api/history/request/$requestId/deploy/$deployId"
+    )
   }
 
-  def getSingularityTaskHistory(requestId: String, deployId: DeployId): Try[Seq[SingularityTaskIdHistory]] = {
-    get[Seq[SingularityTaskIdHistory]](s"$apiUrl/api/history/request/$requestId/tasks?requestId=$requestId&deployId=$deployId")
+  def getSingularityTaskHistory(
+      requestId: String,
+      deployId: DeployId
+  ): Try[Seq[SingularityTaskIdHistory]] = {
+    get[Seq[SingularityTaskIdHistory]](
+      s"$apiUrl/api/history/request/$requestId/tasks?requestId=$requestId&deployId=$deployId"
+    )
   }.map(_.getOrElse(Seq.empty))
 
   /**
-   * Undocumented api to fetch stdout/stderr logs:
-   * https://github.com/HubSpot/Singularity/issues/1309
-   *
-   * @param path stdout or stderr
-   */
+    * Undocumented api to fetch stdout/stderr logs:
+    * https://github.com/HubSpot/Singularity/issues/1309
+    *
+    * @param path stdout or stderr
+    */
   private val DefaultLength = 50000
 
-  def getLogs(taskId: String, path: String): Try[Seq[String]] = for {
-    logOp <- get[SingularityLog](s"$apiUrl/api/sandbox/$taskId/read?path=$path&length=$DefaultLength&offset=0")
-    log <- logOp.toTry("Logs not found")
-  } yield {
-    log.data.split("\n")
-  }
+  def getLogs(taskId: String, path: String): Try[Seq[String]] =
+    for {
+      logOp <- get[SingularityLog](
+        s"$apiUrl/api/sandbox/$taskId/read?path=$path&length=$DefaultLength&offset=0"
+      )
+      log <- logOp.toTry("Logs not found")
+    } yield {
+      log.data.split("\n")
+    }
 
   def getSingularityActiveTasks(): Try[Seq[SingularityTask]] = {
     get[Seq[SingularityTask]](s"$apiUrl/api/tasks/active")
@@ -69,18 +102,24 @@ trait SingularityManager extends HttpClientHelper {
     for {
       allTasks <- getSingularityActiveTasks()
     } yield {
-      allTasks.filter(task => task.taskId.requestId == request.id)
+      allTasks
+        .filter(task => task.taskId.requestId == request.id)
         .sortBy(_.taskId.id) // predictable order
     }
   }
 
   def getSingularityPendingDeploy(): Try[Seq[SingularityPendingDeploy]] = {
-    get[Seq[SingularityPendingDeploy]](s"$apiUrl/api/deploys/pending").map(_.getOrElse(Seq.empty))
+    get[Seq[SingularityPendingDeploy]](s"$apiUrl/api/deploys/pending")
+      .map(_.getOrElse(Seq.empty))
   }
 
-  def getSingularityPendingDeploy(requestId: String, deployId: DeployId): Try[Option[SingularityPendingDeploy]] = {
+  def getSingularityPendingDeploy(
+      requestId: String,
+      deployId: DeployId
+  ): Try[Option[SingularityPendingDeploy]] = {
     getSingularityPendingDeploy().map { allPending =>
-      allPending.filter(_.deployMarker.deployId == deployId)
+      allPending
+        .filter(_.deployMarker.deployId == deployId)
         .filter(_.deployMarker.requestId == requestId)
         .headOption
     }
@@ -88,7 +127,9 @@ trait SingularityManager extends HttpClientHelper {
 
   // Retrieve the list of active requests
   def getSingularityActiveRequests(): Try[Seq[SingularityRequestParent]] = {
-    get[Seq[SingularityRequestParent]](s"$apiUrl/api/requests/active?includeFullRequestData=true").map(_.getOrElse(Seq.empty))
+    get[Seq[SingularityRequestParent]](
+      s"$apiUrl/api/requests/active?includeFullRequestData=true"
+    ).map(_.getOrElse(Seq.empty))
   }
 
   def withDisabledDebugLog(): SingularityManager
@@ -96,40 +137,64 @@ trait SingularityManager extends HttpClientHelper {
 }
 
 /**
- * Singularity Manager in Dryrun mode.
- */
-case class DryrunSingularityManager(apiUrl: String, log: Logger) extends SingularityManager {
+  * Singularity Manager in Dryrun mode.
+  */
+case class DryrunSingularityManager(apiUrl: String, log: Logger)
+    extends SingularityManager {
 
   def createSingularityRequest(newRequest: SingularityRequest) = {
     if (newRequest.schedule.isDefined) {
-      log.info(s" [dryrun] Need to schedule a new Mesos Job with id: ${newRequest.id}")
+      log.info(
+        s" [dryrun] Need to schedule a new Mesos Job with id: ${newRequest.id}"
+      )
     } else {
-      log.info(s" [dryrun] Need to create a new Mesos service with id: ${newRequest.id}, instances: ${newRequest.instances.getOrElse("0")}")
+      log.info(
+        s" [dryrun] Need to create a new Mesos service with id: ${newRequest.id}, instances: ${newRequest.instances
+          .getOrElse("0")}"
+      )
     }
     Success(SingularityRequestParent(request = newRequest, state = "ACTIVE"))
   }
 
-  def scaleSingularityRequest(previous: SingularityRequest, request: SingularityRequest) = {
-    log.info(s""" [dryrun] Need to scale from ${previous.instances.getOrElse("0")} to ${request.instances.getOrElse("0")} instances""")
+  def scaleSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ) = {
+    log.info(s""" [dryrun] Need to scale from ${previous.instances.getOrElse(
+      "0"
+    )} to ${request.instances.getOrElse("0")} instances""")
     Success(SingularityUpdateResult(state = "ACTIVE"))
   }
 
-  def updateSingularityRequest(previous: SingularityRequest, request: SingularityRequest) = {
+  def updateSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ) = {
     log.info(s" [dryrun] Need to update ${request.id}")
     if (previous.schedule != request.schedule) {
-      log.info(s""" [dryrun] Need to reschedule '${previous.schedule.getOrElse("")}' to '${previous.schedule.getOrElse("")}'""")
+      log.info(s""" [dryrun] Need to reschedule '${previous.schedule.getOrElse(
+        ""
+      )}' to '${previous.schedule.getOrElse("")}'""")
     }
 
     Success(SingularityUpdateResult(state = "ACTIVE"))
   }
 
-  def deploySingularityDeploy(currentRequest: SingularityRequest, newDeploy: SingularityDeploy, message: String): Try[SingularityRequestParent] = {
-    val message = s" [dryrun] Need to deploy image '${newDeploy.containerInfo.docker.image}'"
+  def deploySingularityDeploy(
+      currentRequest: SingularityRequest,
+      newDeploy: SingularityDeploy,
+      message: String
+  ): Try[SingularityRequestParent] = {
+    val message =
+      s" [dryrun] Need to deploy image '${newDeploy.containerInfo.docker.image}'"
     log.info(message)
     val detail = ModelConversions.describeDeploy(currentRequest, newDeploy)
-    log.info(
-      s""" [dryrun] Deploy to apply:
-         |${detail.mkString("           * ", "\n           * ", "")}""".stripMargin)
+    log.info(s""" [dryrun] Deploy to apply:
+         |${detail.mkString(
+      "           * ",
+      "\n           * ",
+      ""
+    )}""".stripMargin)
 
     Success(SingularityRequestParent(currentRequest, state = "ACTIVE"))
   }
@@ -138,60 +203,98 @@ case class DryrunSingularityManager(apiUrl: String, log: Logger) extends Singula
 }
 
 /**
- * Singularity Manager with All write operations.
- */
-case class RealSingularityManager(conf: SingularityConf, log: Logger) extends SingularityManager {
+  * Singularity Manager with All write operations.
+  */
+case class RealSingularityManager(conf: SingularityConf, log: Logger)
+    extends SingularityManager {
   val apiUrl: String = conf.url
 
   def createSingularityRequest(newRequest: SingularityRequest) = {
     log.debug("Creating Singularity Request...")
-    val response = post[SingularityRequest, SingularityRequestParent](s"$apiUrl/api/requests", newRequest)
+    val response = post[SingularityRequest, SingularityRequestParent](
+      s"$apiUrl/api/requests",
+      newRequest
+    )
 
     response.foreach {
       case response if (newRequest.schedule.isEmpty) =>
-        log.info(s""" Created new Mesos service with Id: ${newRequest.id}, instances: ${newRequest.instances.getOrElse("0")}, state: ${response.state}""")
+        log.info(
+          s""" Created new Mesos service with Id: ${newRequest.id}, instances: ${newRequest.instances
+            .getOrElse("0")}, state: ${response.state}"""
+        )
       case response if (newRequest.schedule.isDefined) =>
-        log.info(s""" Scheduled new Mesos job with Id: ${newRequest.id}, state: ${response.state}""")
+        log.info(
+          s""" Scheduled new Mesos job with Id: ${newRequest.id}, state: ${response.state}"""
+        )
     }
 
     response
   }
 
-  def scaleSingularityRequest(previous: SingularityRequest, request: SingularityRequest) = {
-    val message = s""" Scaling '${request.id}' from ${previous.instances.getOrElse("0")} to ${request.instances.getOrElse("0")} instances"""
+  def scaleSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ) = {
+    val message =
+      s""" Scaling '${request.id}' from ${previous.instances.getOrElse(
+        "0"
+      )} to ${request.instances.getOrElse("0")} instances"""
     log.info(message)
     val scaleRequest = SingularityScaleRequest(message, request.instances)
 
-    val response = put[SingularityScaleRequest, SingularityUpdateResult](s"$apiUrl/api/requests/request/${request.id}/scale", scaleRequest)
+    val response = put[SingularityScaleRequest, SingularityUpdateResult](
+      s"$apiUrl/api/requests/request/${request.id}/scale",
+      scaleRequest
+    )
 
     response.foreach {
       case response =>
-        log.info(s" ${request.id} scaled, instances: ${request.instances.getOrElse("0")}, state: ${response.state}")
+        log.info(s" ${request.id} scaled, instances: ${request.instances
+          .getOrElse("0")}, state: ${response.state}")
     }
 
     response
   }
 
-  def updateSingularityRequest(previous: SingularityRequest, request: SingularityRequest) = {
+  def updateSingularityRequest(
+      previous: SingularityRequest,
+      request: SingularityRequest
+  ) = {
     log.info(s" Need to update ${request.id}")
     if (previous.schedule != request.schedule) {
-      log.info(s""" Rescheduling '${request.id}' cron from '${previous.schedule.getOrElse("")}' to '${request.schedule.getOrElse("")}'""")
+      log.info(s""" Rescheduling '${request.id}' cron from '${previous.schedule
+        .getOrElse("")}' to '${request.schedule.getOrElse("")}'""")
     }
-    post[SingularityRequest, SingularityUpdateResult](s"$apiUrl/api/requests", request)
+    post[SingularityRequest, SingularityUpdateResult](
+      s"$apiUrl/api/requests",
+      request
+    )
   }
 
-  def deploySingularityDeploy(currentRequest: SingularityRequest, newDeploy: SingularityDeploy, message: String) = {
+  def deploySingularityDeploy(
+      currentRequest: SingularityRequest,
+      newDeploy: SingularityDeploy,
+      message: String
+  ) = {
     log.info(message)
-    log.debug(s" [requestId: ${newDeploy.requestId}, deployId: ${newDeploy.id}]")
+    log.debug(
+      s" [requestId: ${newDeploy.requestId}, deployId: ${newDeploy.id}]"
+    )
 
-    val deployRequest = SingularityDeployRequest(newDeploy, message, unpauseOnSuccessfulDeploy = true)
+    val deployRequest = SingularityDeployRequest(
+      newDeploy,
+      message,
+      unpauseOnSuccessfulDeploy = true
+    )
 
-    val response = post[SingularityDeployRequest, SingularityRequestParent](s"$apiUrl/api/deploys", deployRequest)
+    val response = post[SingularityDeployRequest, SingularityRequestParent](
+      s"$apiUrl/api/deploys",
+      deployRequest
+    )
 
     response.foreach { _ =>
       val detail = ModelConversions.describeDeploy(currentRequest, newDeploy)
-      log.info(
-        s""" Deploy applied:
+      log.info(s""" Deploy applied:
            |${detail.mkString("   * ", "\n   * ", "")}""".stripMargin)
 
     }

--- a/shared/src/main/scala/com/nitro/nmesos/singularity/model.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/singularity/model.scala
@@ -5,169 +5,177 @@ import com.nitro.nmesos.singularity.model.SingularityRequestParent.SingularityAc
 import com.nitro.nmesos.singularity.model.SingularityTask.SingularityTaskInfo
 
 /**
- * Subset of the Singularity api Model.
- *
- * @see http://getsingularity.com/Docs/reference/apidocs/models.html
- */
+  * Subset of the Singularity api Model.
+  *
+  * @see http://getsingularity.com/Docs/reference/apidocs/models.html
+  */
 object model {
 
   // Mesos resources
   case class SingularityResources(
-    cpus: Double,
-    memoryMb: Double,
-    numPorts: Int,
-    diskMb: Int)
+      cpus: Double,
+      memoryMb: Double,
+      numPorts: Int,
+      diskMb: Int
+  )
 
   case class SingularityDockerPortMapping(
-    containerPort: Int,
-    hostPortType: String,
-    containerPortType: String,
-    hostPort: Int,
-    protocol: String)
+      containerPort: Int,
+      hostPortType: String,
+      containerPortType: String,
+      hostPort: Int,
+      protocol: String
+  )
 
   case class SingularityDockerInfo(
-    network: String,
-    image: String,
-    portMappings: Seq[SingularityDockerPortMapping],
-    forcePullImage: Boolean,
-    dockerParameters: Seq[SingularityDockerParameter])
+      network: String,
+      image: String,
+      portMappings: Seq[SingularityDockerPortMapping],
+      forcePullImage: Boolean,
+      dockerParameters: Seq[SingularityDockerParameter]
+  )
 
-  case class SingularityDockerParameter(
-    key: String,
-    value: String)
+  case class SingularityDockerParameter(key: String, value: String)
 
   case class SingularityVolume(
-    hostPath: String,
-    containerPath: String,
-    mode: String)
+      hostPath: String,
+      containerPath: String,
+      mode: String
+  )
 
   case class SingularityContainerInfo(
-    `type`: String,
-    docker: SingularityDockerInfo,
-    volumes: Seq[SingularityVolume])
+      `type`: String,
+      docker: SingularityDockerInfo,
+      volumes: Seq[SingularityVolume]
+  )
 
   case class SingularityDeploy(
-    requestId: String,
-    id: String,
-    resources: SingularityResources,
-    containerInfo: SingularityContainerInfo,
-    command: Option[String] = None,
-    shell: Option[Boolean] = None,
-    deployInstanceCountPerStep: Option[Int] = None,
-    deployStepWaitTimeMs: Option[Int] = None,
-    deployHealthTimeoutSeconds: Option[Int] = None,
-    autoAdvanceDeploySteps: Option[Boolean] = None,
-    customExecutorCmd: Option[String] = None,
-    env: Map[String, String] = Map.empty,
-    healthcheckUri: Option[String] = None,
-    healthcheckPortIndex: Option[Int] = None,
-    healthcheckMaxRetries: Option[Int] = None,
-    healthcheckTimeoutSeconds: Option[Int] = None,
-    healthcheckMaxTotalTimeoutSeconds: Option[Int] = None)
+      requestId: String,
+      id: String,
+      resources: SingularityResources,
+      containerInfo: SingularityContainerInfo,
+      command: Option[String] = None,
+      shell: Option[Boolean] = None,
+      deployInstanceCountPerStep: Option[Int] = None,
+      deployStepWaitTimeMs: Option[Int] = None,
+      deployHealthTimeoutSeconds: Option[Int] = None,
+      autoAdvanceDeploySteps: Option[Boolean] = None,
+      customExecutorCmd: Option[String] = None,
+      env: Map[String, String] = Map.empty,
+      healthcheckUri: Option[String] = None,
+      healthcheckPortIndex: Option[Int] = None,
+      healthcheckMaxRetries: Option[Int] = None,
+      healthcheckTimeoutSeconds: Option[Int] = None,
+      healthcheckMaxTotalTimeoutSeconds: Option[Int] = None
+  )
 
   case class SingularityRequest(
-    id: String,
-    requestType: String,
-    slavePlacement: String,
-    instances: Option[Int] = None,
-    schedule: Option[String] = None,
-    requiredSlaveAttributes: Map[String, String] = Map.empty,
-    allowedSlaveAttributes: Map[String, String] = Map.empty,
-    requiredRole: Option[String] = None)
+      id: String,
+      requestType: String,
+      slavePlacement: String,
+      instances: Option[Int] = None,
+      schedule: Option[String] = None,
+      requiredSlaveAttributes: Map[String, String] = Map.empty,
+      allowedSlaveAttributes: Map[String, String] = Map.empty,
+      requiredRole: Option[String] = None
+  )
 
   case class SingularityDeployRequest(
-    deploy: SingularityDeploy,
-    message: String,
-    unpauseOnSuccessfulDeploy: Boolean)
+      deploy: SingularityDeploy,
+      message: String,
+      unpauseOnSuccessfulDeploy: Boolean
+  )
 
   case class SingularityScaleRequest(
-    message: String,
-    instances: Option[Int] = None,
-    skipHealthchecks: Boolean = true //If set to true, healthchecks will be skipped while scaling this request (only)
+      message: String,
+      instances: Option[Int] = None,
+      skipHealthchecks: Boolean =
+        true //If set to true, healthchecks will be skipped while scaling this request (only)
   )
 
   object SingularityRequestParent {
     case class SingularityActiveDeployResponse(
-      id: DeployId,
-      resources: SingularityResources)
+        id: DeployId,
+        resources: SingularityResources
+    )
   }
 
   case class SingularityRequestParent(
-    request: SingularityRequest,
-    state: String,
-    taskIds: Option[SingularityTaskIdsByStatus] = None,
-    activeDeploy: Option[SingularityActiveDeployResponse] = None)
+      request: SingularityRequest,
+      state: String,
+      taskIds: Option[SingularityTaskIdsByStatus] = None,
+      activeDeploy: Option[SingularityActiveDeployResponse] = None
+  )
 
   case class SingularityDeployResult(
-    deployState: String,
-    message: Option[String] = None,
-    deployFailures: Seq[SingularityDeployFailure] = Seq.empty)
+      deployState: String,
+      message: Option[String] = None,
+      deployFailures: Seq[SingularityDeployFailure] = Seq.empty
+  )
 
   case class SingularityDeployFailure(
-    reason: String,
-    taskId: SingularityTaskId,
-    message: Option[String] = None)
+      reason: String,
+      taskId: SingularityTaskId,
+      message: Option[String] = None
+  )
 
-  case class SingularityUpdateResult(
-    state: String)
+  case class SingularityUpdateResult(state: String)
 
   case class SingularityDeployHistory(
-    deploy: SingularityDeploy,
-    deployResult: Option[SingularityDeployResult] = None)
+      deploy: SingularityDeploy,
+      deployResult: Option[SingularityDeployResult] = None
+  )
 
   case class SingularityPendingDeploy(
-    currentDeployState: String,
-    deployMarker: SingularityDeployMarker,
-    deployProgress: SingularityDeployProgress)
+      currentDeployState: String,
+      deployMarker: SingularityDeployMarker,
+      deployProgress: SingularityDeployProgress
+  )
 
-  case class SingularityDeployProgress(
-    targetActiveInstances: Int)
+  case class SingularityDeployProgress(targetActiveInstances: Int)
 
-  case class SingularityDeployMarker(
-    requestId: String,
-    deployId: String)
+  case class SingularityDeployMarker(requestId: String, deployId: String)
 
   case class SingularityTaskId(
-    requestId: String,
-    host: String,
-    sanitizedHost: String,
-    deployId: String,
-    id: String,
-    instanceNo: Int)
+      requestId: String,
+      host: String,
+      sanitizedHost: String,
+      deployId: String,
+      id: String,
+      instanceNo: Int
+  )
 
   case class SingularityTaskIdHistory(
-    lastTaskState: String,
-    taskId: SingularityTaskId)
+      lastTaskState: String,
+      taskId: SingularityTaskId
+  )
 
   object SingularityTask {
 
     case class SingularityTasKDockerPortMapping(
-      containerPort: Int,
-      hostPort: Int)
+        containerPort: Int,
+        hostPort: Int
+    )
 
     case class SingularityTaskDockerInfo(
-      portMappings: Seq[SingularityTasKDockerPortMapping])
+        portMappings: Seq[SingularityTasKDockerPortMapping]
+    )
 
-    case class SingularityTaskIContainerInfo(
-      docker: SingularityTaskDockerInfo)
+    case class SingularityTaskIContainerInfo(docker: SingularityTaskDockerInfo)
 
-    case class SingularityTaskInfo(
-      container: SingularityTaskIContainerInfo)
+    case class SingularityTaskInfo(container: SingularityTaskIContainerInfo)
 
   }
 
   case class SingularityTask(
-    taskId: SingularityTaskId,
-    mesosTask: SingularityTaskInfo,
-    offer: Offer)
+      taskId: SingularityTaskId,
+      mesosTask: SingularityTaskInfo,
+      offer: Offer
+  )
 
-  case class Offer(
-    hostname: String)
+  case class Offer(hostname: String)
 
-  case class SingularityLog(
-    data: String,
-    offset: Int)
+  case class SingularityLog(data: String, offset: Int)
 
-  case class SingularityTaskIdsByStatus(
-    healthy: Seq[SingularityTaskId])
+  case class SingularityTaskIdsByStatus(healthy: Seq[SingularityTaskId])
 }

--- a/shared/src/main/scala/com/nitro/nmesos/util/Logger.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/util/Logger.scala
@@ -3,8 +3,8 @@ package com.nitro.nmesos.util
 import scala.annotation.tailrec
 
 /**
- * Basic terminal output for the CLI app.
- */
+  * Basic terminal output for the CLI app.
+  */
 trait Logger extends AnsiLogger with Animations {
 
   def error(msg: => Any): Unit = println(errorColor(msg))
@@ -25,13 +25,13 @@ trait Logger extends AnsiLogger with Animations {
 }
 
 /**
- * Default terminal output with verbose disabled and ansi colors disabled.
- */
+  * Default terminal output with verbose disabled and ansi colors disabled.
+  */
 object InfoLogger extends CustomLogger(ansiEnabled = false, verbose = false)
 
 /**
- * Terminal output with verbose enabled and ansi colors enabled.
- */
+  * Terminal output with verbose enabled and ansi colors enabled.
+  */
 case class CustomLogger(ansiEnabled: Boolean, verbose: Boolean) extends Logger {
   def debug(msg: => Any): Unit = if (verbose) println(s" [debug] $msg") else {}
 }
@@ -82,10 +82,13 @@ trait Animations extends AnsiLogger {
   private val frames = "|/-\\".toCharArray
 
   /**
-   * Show while body is not None
-   */
+    * Show while body is not None
+    */
   @tailrec
-  final def showAnimated(fetchMessage: () => Option[String], step: Int = 0): Unit = {
+  final def showAnimated(
+      fetchMessage: () => Option[String],
+      step: Int = 0
+  ): Unit = {
     fetchMessage() match {
       case None =>
         eraseLine()

--- a/shared/src/main/scala/com/nitro/nmesos/util/utils.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/util/utils.scala
@@ -4,16 +4,17 @@ import com.nitro.nmesos.BuildInfo
 import org.joda.time.DateTime
 
 import scala.annotation.tailrec
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 // Scala conversions boilerplate .
 object Conversions {
 
   implicit class OptionToTry[A](opt: Option[A]) {
-    def toTry(error: String) = opt match {
-      case None => Failure(sys.error(error))
-      case Some(value) => Success(value)
-    }
+    def toTry(error: String) =
+      opt match {
+        case None        => Failure(sys.error(error))
+        case Some(value) => Success(value)
+      }
   }
 
 }
@@ -25,7 +26,10 @@ object HashUtil {
   // Small hash to detect file changes.
   def hash(content: String): String = {
     val md = java.security.MessageDigest.getInstance("SHA-1")
-    md.digest(content.getBytes("UTF-8")).map("%02x".format(_)).mkString.take(HashLength)
+    md.digest(content.getBytes("UTF-8"))
+      .map("%02x".format(_))
+      .mkString
+      .take(HashLength)
   }
 
 }
@@ -39,7 +43,9 @@ object VersionUtil {
   val VersionField = "nmesos_version"
 
   def tryExtractFromYaml(sourceYml: String): Try[Version] = {
-    val tryVersionLine = sourceYml.lines.find(_.contains(VersionField)).toTry(s"$VersionField no present in the config file")
+    val tryVersionLine = sourceYml.lines
+      .find(_.contains(VersionField))
+      .toTry(s"$VersionField no present in the config file")
 
     for {
       versionLine <- tryVersionLine
@@ -47,12 +53,13 @@ object VersionUtil {
     } yield version
   }
 
-  def tryExtract(version: String): Try[Version] = version match {
-    case VersionPattern(major, minor, patch) =>
-      Success(List(major.toInt, minor.toInt, patch.toInt))
-    case invalid =>
-      Failure(sys.error(s"Unable to extract version from $invalid"))
-  }
+  def tryExtract(version: String): Try[Version] =
+    version match {
+      case VersionPattern(major, minor, patch) =>
+        Success(List(major.toInt, minor.toInt, patch.toInt))
+      case invalid =>
+        Failure(sys.error(s"Unable to extract version from $invalid"))
+    }
 
   // Compare yaml required version vs installed version.
   def isCompatible(requiredVersion: Version, log: Logger): Boolean = {
@@ -69,15 +76,20 @@ object VersionUtil {
   }
 
   // compare compatibility between semantic versions
-  def isCompatible(requiredVersion: Version, installedVersion: Version): Boolean = {
+  def isCompatible(
+      requiredVersion: Version,
+      installedVersion: Version
+  ): Boolean = {
     val zip = requiredVersion.zip(installedVersion)
 
-    def compareVersions(remaining: List[(Int, Int)]): Boolean = remaining match {
-      case Nil => true
-      case (required, installed) :: tail if (required > installed) => false
-      case (required, installed) :: tail if (required < installed) => true
-      case (required, installed) :: tail if (required == installed) => compareVersions(tail)
-    }
+    def compareVersions(remaining: List[(Int, Int)]): Boolean =
+      remaining match {
+        case Nil                                                     => true
+        case (required, installed) :: tail if (required > installed) => false
+        case (required, installed) :: tail if (required < installed) => true
+        case (required, installed) :: tail if (required == installed) =>
+          compareVersions(tail)
+      }
 
     compareVersions(zip)
   }
@@ -87,7 +99,8 @@ object VersionUtil {
 object SequenceUtil {
   val SequenceBaseTime = new DateTime(2016, 12, 1, 0, 0)
 
-  def sequenceId(): Long = (DateTime.now.getMillis / 1000) - (SequenceBaseTime.getMillis / 1000)
+  def sequenceId(): Long =
+    (DateTime.now.getMillis / 1000) - (SequenceBaseTime.getMillis / 1000)
 }
 
 object WaitUtil {

--- a/shared/src/test/resources/config/example-config-run-local.yml
+++ b/shared/src/test/resources/config/example-config-run-local.yml
@@ -1,0 +1,25 @@
+## Example config for testing
+nmesos_version: '0.0.1' ## Min nmesos required to execute this config
+
+common:
+
+  resources:
+    instances: 2 # Number of instances to deploy
+    cpus: 0.1
+    memoryMb: 64
+
+  container:
+
+    image: hubspot/singularity-test-service # Docker repo/image without the tag
+
+    ports:
+      - 4000 # Exposed port by the container (Mesos will auto assign a external port)
+
+    env_vars:
+      MY_ENV_VAR_1: "MY_ENV_VAR_1"
+      MY_ENV_VAR_2: "MY_ENV_VAR_2"
+
+environments:
+  dev:
+    singularity:
+      url: "http://localhost:7099/singularity"

--- a/shared/src/test/scala/com/nitro/nmesos/commands/RunLocalCommandSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/commands/RunLocalCommandSpec.scala
@@ -23,9 +23,7 @@ class RunLocalCommandSpec extends Specification {
       val commandString = RunLocalCommand(
         buildConfig(),
         InfoLogger,
-        isDryrun = true,
-        deprecatedSoftGracePeriod = 10,
-        deprecatedHardGracePeriod = 20
+        isDryrun = true
       ).runLocalCmdString()
 
       commandString must be equalTo "docker run -i -p 4000:4000 -e MY_ENV_VAR_2=MY_ENV_VAR_2 -e MY_ENV_VAR_1=MY_ENV_VAR_1 hubspot/singularity-test-service:latest"

--- a/shared/src/test/scala/com/nitro/nmesos/commands/RunLocalCommandSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/commands/RunLocalCommandSpec.scala
@@ -1,0 +1,54 @@
+package com.nitro.nmesos.commands
+
+import java.io.File
+import com.nitro.nmesos.config.YamlParser.ValidYaml
+import com.nitro.nmesos.util.InfoLogger
+import org.specs2.mutable.Specification
+
+import com.nitro.nmesos.singularity.ModelConversions
+import com.nitro.nmesos.util.{CustomLogger, InfoLogger, Logger}
+import com.nitro.nmesos.config.ConfigReader
+import com.nitro.nmesos.config.ConfigReader.ValidConfig
+import com.nitro.nmesos.config.model.CmdConfig
+import org.specs2.mutable.Specification
+import sys.process._
+import scala.language.postfixOps
+
+import scala.io.Source
+
+class RunLocalCommandSpec extends Specification {
+  "Run Local Command" should {
+    "Build a successful `docker run` command string" in {
+
+      val commandString = RunLocalCommand(
+        buildConfig(),
+        InfoLogger,
+        isDryrun = true,
+        deprecatedSoftGracePeriod = 10,
+        deprecatedHardGracePeriod = 20
+      ).runLocalCmdString()
+
+      commandString must be equalTo "docker run -i -p 4000:4000 -e MY_ENV_VAR_2=MY_ENV_VAR_2 -e MY_ENV_VAR_1=MY_ENV_VAR_1 hubspot/singularity-test-service:latest"
+    }
+  }
+
+  private def buildConfig() = {
+    val serviceName =
+      "shared/src/test/resources/config/example-config-run-local.yml"
+    val yamlFile = new File(serviceName)
+    ConfigReader.parseEnvironment(yamlFile, "dev", InfoLogger) match {
+      case validConfig: ValidConfig =>
+        CmdConfig(
+          serviceName,
+          "latest",
+          force = false,
+          validConfig.environmentName,
+          validConfig.environment,
+          validConfig.fileHash,
+          yamlFile
+        )
+      case other => sys.error(other.toString)
+    }
+  }
+
+}

--- a/shared/src/test/scala/com/nitro/nmesos/config/ConfigReaderSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/ConfigReaderSpec.scala
@@ -12,15 +12,22 @@ class ConfigReaderSpec extends Specification with YmlTestFixtures2 {
       val expectedMissingKeys = Map(
         "dev" -> Set("only_prod", "only_test"),
         "prod" -> Set("only_dev", "only_test"),
-        "test" -> Set("only_dev", "only_prod", "dev_and_prod"))
-      val parsed = YamlParser.parse(YamlExampleWithMissingEnvVars, InfoLogger).asInstanceOf[ValidYaml]
-      val missingEnvVarKeys = ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
+        "test" -> Set("only_dev", "only_prod", "dev_and_prod")
+      )
+      val parsed = YamlParser
+        .parse(YamlExampleWithMissingEnvVars, InfoLogger)
+        .asInstanceOf[ValidYaml]
+      val missingEnvVarKeys =
+        ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
       missingEnvVarKeys should be equalTo expectedMissingKeys
     }
 
     "return an empty map when there are no missing env_var keys" in {
-      val parsed = YamlParser.parse(YamlExampleWithValidEnvVars, InfoLogger).asInstanceOf[ValidYaml]
-      val missingEnvVarKeys = ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
+      val parsed = YamlParser
+        .parse(YamlExampleWithValidEnvVars, InfoLogger)
+        .asInstanceOf[ValidYaml]
+      val missingEnvVarKeys =
+        ConfigReader.findMissingContainerEnvVarKeys(parsed.config)
       missingEnvVarKeys should be equalTo Map()
     }
   }
@@ -28,7 +35,21 @@ class ConfigReaderSpec extends Specification with YmlTestFixtures2 {
 }
 
 trait YmlTestFixtures2 {
-  def YamlExampleWithMissingEnvVars = Source.fromURL(getClass.getResource("/config/example-config-with-missing-feature-toggles.yml")).mkString
+  def YamlExampleWithMissingEnvVars =
+    Source
+      .fromURL(
+        getClass.getResource(
+          "/config/example-config-with-missing-feature-toggles.yml"
+        )
+      )
+      .mkString
 
-  def YamlExampleWithValidEnvVars = Source.fromURL(getClass.getResource("/config/example-config-with-feature-toggles-for-one-environment.yml")).mkString
+  def YamlExampleWithValidEnvVars =
+    Source
+      .fromURL(
+        getClass.getResource(
+          "/config/example-config-with-feature-toggles-for-one-environment.yml"
+        )
+      )
+      .mkString
 }

--- a/shared/src/test/scala/com/nitro/nmesos/config/ValidationsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/ValidationsSpec.scala
@@ -13,13 +13,20 @@ class ValidationsSpec extends Specification {
 
     "succeed when there is enough memory" in {
       val expectedResult = Seq(Ok("Resources - Memory Instances"))
-      Validations.checkResources(model.Resources(0.0, 1, None)) should be equalTo expectedResult
+      Validations.checkResources(
+        model.Resources(0.0, 1, None)
+      ) should be equalTo expectedResult
     }
 
     "fail when there is not enough memory" in {
-      val expectedResult = Seq(Fail("Resources - Memory Instances", "Must be > 0"))
-      Validations.checkResources(model.Resources(0.0, 0, None)) should be equalTo expectedResult
-      Validations.checkResources(model.Resources(0.0, -1, None)) should be equalTo expectedResult
+      val expectedResult =
+        Seq(Fail("Resources - Memory Instances", "Must be > 0"))
+      Validations.checkResources(
+        model.Resources(0.0, 0, None)
+      ) should be equalTo expectedResult
+      Validations.checkResources(
+        model.Resources(0.0, -1, None)
+      ) should be equalTo expectedResult
     }
 
   }
@@ -27,14 +34,40 @@ class ValidationsSpec extends Specification {
   "Validations checkContainers" should {
 
     "succeed when there are labels and env_vars" in {
-      val container = model.Container("", None, None, None, Some(Map("label" -> "red")), Some(Map("env" -> "var")), None, None, None, None)
-      val expectedResult = Seq(Ok("Container - Labels"), Ok("Container - Environment vars"))
+      val container = model.Container(
+        "",
+        None,
+        None,
+        None,
+        Some(Map("label" -> "red")),
+        Some(Map("env" -> "var")),
+        None,
+        None,
+        None,
+        None
+      )
+      val expectedResult =
+        Seq(Ok("Container - Labels"), Ok("Container - Environment vars"))
       Validations.checkContainer(container) should be equalTo expectedResult
     }
 
     "warn when there are no labels and/or no env_vars" in {
-      val container = model.Container("", None, None, None, None, None, None, None, None, None)
-      val expectedResult = Seq(Warning("Container - Labels", "No labels defined"), Warning("Container - Environment vars", "No env vars defined"))
+      val container = model.Container(
+        "",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
+      val expectedResult = Seq(
+        Warning("Container - Labels", "No labels defined"),
+        Warning("Container - Environment vars", "No env vars defined")
+      )
       Validations.checkContainer(container) should be equalTo expectedResult
     }
 
@@ -44,8 +77,36 @@ class ValidationsSpec extends Specification {
 
     "skip/ignore when it is not a scheduled job" in {
       val resources = model.Resources(0.0, 0, None)
-      val container = model.Container("", None, None, None, None, None, None, None, None, None)
-      val singularity = model.SingularityConf("", None, Some("SERVICE"), None, None, None, None, None, None, None, None, None, None, None, None, None)
+      val container = model.Container(
+        "",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
+      val singularity = model.SingularityConf(
+        "",
+        None,
+        Some("SERVICE"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
       val env = model.Environment(resources, container, None, singularity, None)
       Validations.checkScheduledJob(env) should be empty
     }
@@ -56,8 +117,36 @@ class ValidationsSpec extends Specification {
 
     "skip/ignore when it is not a service" in {
       val resources = model.Resources(0.0, 0, None)
-      val container = model.Container("", None, None, None, None, None, None, None, None, None)
-      val singularity = model.SingularityConf("", None, Some("SCHEDULED"), None, None, None, None, None, None, None, None, None, None, None, None, None)
+      val container = model.Container(
+        "",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
+      val singularity = model.SingularityConf(
+        "",
+        None,
+        Some("SCHEDULED"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
       val env = model.Environment(resources, container, None, singularity, None)
       Validations.checkService(env) should be empty
     }
@@ -67,21 +156,37 @@ class ValidationsSpec extends Specification {
   "Validations checkDeprecated" should {
 
     "succeed if no env_vars are expired" in {
-      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+      val today = LocalDate.parse(
+        "30-Jan-2020",
+        DateTimeFormatter.ofPattern("dd-MMM-yyyy")
+      )
       val expectedResult = Seq(
         Ok("Deprecated Env Var - OLD_ENV_VAR_10"),
         Ok("Deprecated Env Var - OLD_ENV_VAR_20"),
-        Ok("Deprecated Env Var - OLD_ENV_VAR_30"))
-      Validations.checkDeprecated(deprecatedEnvVarFile(), today, (21, 21)) should be equalTo expectedResult
+        Ok("Deprecated Env Var - OLD_ENV_VAR_30")
+      )
+      Validations.checkDeprecated(
+        deprecatedEnvVarFile(),
+        today,
+        (21, 21)
+      ) should be equalTo expectedResult
     }
 
     "fail/warn if env_vars are expired" in {
-      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+      val today = LocalDate.parse(
+        "30-Jan-2020",
+        DateTimeFormatter.ofPattern("dd-MMM-yyyy")
+      )
       val expectedResult = Seq(
         Fail("Deprecated Env Var - OLD_ENV_VAR_10", "< 20"),
         Warning("Deprecated Env Var - OLD_ENV_VAR_20", "< 10"),
-        Ok("Deprecated Env Var - OLD_ENV_VAR_30"))
-      Validations.checkDeprecated(deprecatedEnvVarFile(), today, (10, 20)) should be equalTo expectedResult
+        Ok("Deprecated Env Var - OLD_ENV_VAR_30")
+      )
+      Validations.checkDeprecated(
+        deprecatedEnvVarFile(),
+        today,
+        (10, 20)
+      ) should be equalTo expectedResult
     }
 
   }
@@ -90,18 +195,26 @@ class ValidationsSpec extends Specification {
 
     "succeed, if a well formed line needs to get processes" in {
       val line = "OLD_ENV_VAR_10: \"old value\" # @deprecated-on 10-Jan-2020"
-      val expectedDate = LocalDate.parse("10-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
-      Validations.processLine(line) should be equalTo ("OLD_ENV_VAR_10", expectedDate)
+      val expectedDate = LocalDate.parse(
+        "10-Jan-2020",
+        DateTimeFormatter.ofPattern("dd-MMM-yyyy")
+      )
+      Validations.processLine(
+        line
+      ) should be equalTo ("OLD_ENV_VAR_10", expectedDate)
     }
 
     "fail, if a badly formed line needs to get processes" in {
-      val line = "OLD_ENV_VAR_10: \"old value\" # @deprecated-on-bad 10-Jan-2020"
+      val line =
+        "OLD_ENV_VAR_10: \"old value\" # @deprecated-on-bad 10-Jan-2020"
       Validations.processLine(line) should throwA[scala.MatchError]
     }
 
     "fail, if a badly formed date needs to get processes" in {
       val line = "OLD_ENV_VAR_10: \"old value\" # @deprecated-on 10-JAN-2020"
-      Validations.processLine(line) should throwA[java.time.format.DateTimeParseException]
+      Validations.processLine(line) should throwA[
+        java.time.format.DateTimeParseException
+      ]
     }
   }
 
@@ -112,6 +225,10 @@ class ValidationsSpec extends Specification {
    * OLD_ENV_VAR_30: "old value" # @deprecated-on 30-Jan-2020
    */
   private def deprecatedEnvVarFile(): java.io.File = {
-    new java.io.File(getClass.getResource("/config/example-config-with-deprecated-env-vars.yml").getPath)
+    new java.io.File(
+      getClass
+        .getResource("/config/example-config-with-deprecated-env-vars.yml")
+        .getPath
+    )
   }
 }

--- a/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/YmlSpec.scala
@@ -10,63 +10,95 @@ import org.specs2.mutable.Specification
 import scala.io.Source
 
 /**
- * Test Yaml config file
- */
+  * Test Yaml config file
+  */
 class YmlSpec extends Specification with YmlTestFixtures {
 
   "Yml Parser" should {
 
     "fail while reading an invalid YML file" in {
-      val ExpectedMessage = "Invalid yaml file at line 9, column: 1\n     WTF!\n     ^"
-      YamlParser.parse(YamlInvalidRandom, InfoLogger) should be equalTo InvalidYaml(ExpectedMessage)
+      val ExpectedMessage =
+        "Invalid yaml file at line 9, column: 1\n     WTF!\n     ^"
+      YamlParser.parse(
+        YamlInvalidRandom,
+        InfoLogger
+      ) should be equalTo InvalidYaml(ExpectedMessage)
     }
 
     "fail while reading a valid YML file without version" in {
-      val ExpectedMessage = "Parser error for field nmesos_version: YamlObject is missing required member 'nmesos_version'"
-      YamlParser.parse(YamlInvalidWithoutVersion, InfoLogger) should be equalTo InvalidYaml(ExpectedMessage)
+      val ExpectedMessage =
+        "Parser error for field nmesos_version: YamlObject is missing required member 'nmesos_version'"
+      YamlParser.parse(
+        YamlInvalidWithoutVersion,
+        InfoLogger
+      ) should be equalTo InvalidYaml(ExpectedMessage)
     }
 
     "fail while reading a valid YML file without all the required config parameters" in {
-      val ExpectedMessage = "Parser error for field nmesos_version: YamlObject is missing required member 'nmesos_version'"
-      YamlParser.parse(YamlInvalidWithIncompleteConf, InfoLogger) should be equalTo InvalidYaml(ExpectedMessage)
+      val ExpectedMessage =
+        "Parser error for field nmesos_version: YamlObject is missing required member 'nmesos_version'"
+      YamlParser.parse(
+        YamlInvalidWithIncompleteConf,
+        InfoLogger
+      ) should be equalTo InvalidYaml(ExpectedMessage)
     }
 
     "return a valid config from a valid Yaml file" in {
-      YamlParser.parse(YamlExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
+      YamlParser
+        .parse(YamlExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
     }
 
     "return a valid config from a valid Yaml with optional singularity config missing" in {
-      YamlParser.parse(YamlJobExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
+      YamlParser
+        .parse(YamlJobExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
     }
 
     "return a valid config from a valid Yaml with optional envar config being empty" in {
-      YamlParser.parse(YamlEnvVarExampleValid, InfoLogger) should beAnInstanceOf[ValidYaml]
+      YamlParser.parse(
+        YamlEnvVarExampleValid,
+        InfoLogger
+      ) should beAnInstanceOf[ValidYaml]
     }
 
     "parse the executor configuration in a valid Yaml file" in {
       val conf = YamlParser.parse(YamlExampleExecutorEnvs, InfoLogger)
       conf should beAnInstanceOf[ValidYaml]
 
-      val ExpectedConf = Some(ExecutorConf(
-        customExecutorCmd = Some("/opt/mesos/executor.sh"),
-        env_vars = Some(Map(
-          "EXECUTOR_SIDECAR_DISCOVER" -> "false",
-          "EXECUTOR_SIDECAR_BACKOFF" -> "20m"))))
+      val ExpectedConf = Some(
+        ExecutorConf(
+          customExecutorCmd = Some("/opt/mesos/executor.sh"),
+          env_vars = Some(
+            Map(
+              "EXECUTOR_SIDECAR_DISCOVER" -> "false",
+              "EXECUTOR_SIDECAR_BACKOFF" -> "20m"
+            )
+          )
+        )
+      )
       val modelConfig = conf.asInstanceOf[ValidYaml].config
       modelConfig.environments("dev").executor should be equalTo ExpectedConf
 
-      modelConfig.environments("dev").singularity.requiredRole should be equalTo Some("OPS")
-      modelConfig.environments("dev").singularity.slavePlacement should be equalTo Some("SPREAD_ALL_SLAVES")
+      modelConfig
+        .environments("dev")
+        .singularity
+        .requiredRole should be equalTo Some("OPS")
+      modelConfig
+        .environments("dev")
+        .singularity
+        .slavePlacement should be equalTo Some("SPREAD_ALL_SLAVES")
     }
 
     "parse the mesos slaves required and allowed attributes in a valid Yaml file" in {
       val conf = YamlParser.parse(YamlMesosAttributeConfig, InfoLogger)
       conf should beAnInstanceOf[ValidYaml]
-      val singularity = conf.asInstanceOf[ValidYaml].config.environments("dev").singularity
-      singularity.requiredAttributes shouldEqual Some(Map(
-        "mesosfunction" -> "master-prod",
-        "Role" -> "docker-host"))
-      singularity.allowedSlaveAttributes shouldEqual Some(Map("compute_class" -> "high_cpu"))
+      val singularity =
+        conf.asInstanceOf[ValidYaml].config.environments("dev").singularity
+      singularity.requiredAttributes shouldEqual Some(
+        Map("mesosfunction" -> "master-prod", "Role" -> "docker-host")
+      )
+      singularity.allowedSlaveAttributes shouldEqual Some(
+        Map("compute_class" -> "high_cpu")
+      )
     }
 
     "parse the port config from a valid Yaml file" in {
@@ -74,33 +106,51 @@ class YmlSpec extends Specification with YmlTestFixtures {
       parsedYaml should beAnInstanceOf[ValidYaml]
 
       val conf = parsedYaml.asInstanceOf[ValidYaml].config
-      conf.environments("dev").container.ports must beSome.which(_.map(portMap => portMap.hostPort match {
-        case Some(hostPort) => portMap should be equalTo PortMap(9000, Option(12000), None)
-        case None => portMap.protocols match {
-          case None => portMap.containerPort should be equalTo 8080
-          case Some(protocols) => {
-            portMap.containerPort should be equalTo 6060
-            protocols mustEqual "udp,tcp"
+      conf.environments("dev").container.ports must beSome.which(
+        _.map(portMap =>
+          portMap.hostPort match {
+            case Some(hostPort) =>
+              portMap should be equalTo PortMap(9000, Option(12000), None)
+            case None =>
+              portMap.protocols match {
+                case None => portMap.containerPort should be equalTo 8080
+                case Some(protocols) => {
+                  portMap.containerPort should be equalTo 6060
+                  protocols mustEqual "udp,tcp"
+                }
+              }
           }
-        }
-      }))
+        )
+      )
     }
 
     "parse the port config from a valid Yaml file and re-serialize it to Yaml" in {
-      val parsedYaml = YamlParser.parse(YamlExamplePortConfigAllVariations, InfoLogger)
+      val parsedYaml =
+        YamlParser.parse(YamlExamplePortConfigAllVariations, InfoLogger)
       parsedYaml should beAnInstanceOf[ValidYaml]
 
-      parsedYaml.asInstanceOf[ValidYaml].config.toYaml.prettyPrint mustEqual ExpectedYamlExamplePortConfig
+      parsedYaml
+        .asInstanceOf[ValidYaml]
+        .config
+        .toYaml
+        .prettyPrint mustEqual ExpectedYamlExamplePortConfig
     }
 
     "fail while parsing an invalid port specification" in {
-      val ExpectedMessage = "Parser error for field environments/container/ports: Failed to deserialize the port specification"
-      YamlParser.parse(YamlInvalidPortConfig, InfoLogger) mustEqual InvalidYaml(ExpectedMessage)
+      val ExpectedMessage =
+        "Parser error for field environments/container/ports: Failed to deserialize the port specification"
+      YamlParser.parse(YamlInvalidPortConfig, InfoLogger) mustEqual InvalidYaml(
+        ExpectedMessage
+      )
     }
 
     "fail while parsing an invalid port specification" in {
-      val ExpectedMessage = "Parser error for field environments/container/ports: Failed to deserialize the port map specification"
-      YamlParser.parse(YamlInvalidPortMapConfig, InfoLogger) mustEqual InvalidYaml(ExpectedMessage)
+      val ExpectedMessage =
+        "Parser error for field environments/container/ports: Failed to deserialize the port map specification"
+      YamlParser.parse(
+        YamlInvalidPortMapConfig,
+        InfoLogger
+      ) mustEqual InvalidYaml(ExpectedMessage)
     }
 
     "parse the after deploy configuration in a valid Yaml file" in {
@@ -108,8 +158,10 @@ class YmlSpec extends Specification with YmlTestFixtures {
       conf should beAnInstanceOf[ValidYaml]
 
       val modelConfig = conf.asInstanceOf[ValidYaml].config
-      val successJob1 = modelConfig.environments("dev").after_deploy.get.on_success.head
-      val successJob2 = modelConfig.environments("dev").after_deploy.get.on_success.drop(1).head
+      val successJob1 =
+        modelConfig.environments("dev").after_deploy.get.on_success.head
+      val successJob2 =
+        modelConfig.environments("dev").after_deploy.get.on_success.drop(1).head
 
       successJob1.service_name shouldEqual "job1"
       successJob1.tag shouldEqual Some("job1tag")
@@ -117,18 +169,31 @@ class YmlSpec extends Specification with YmlTestFixtures {
       successJob2.service_name shouldEqual "job2"
       successJob2.tag shouldEqual None
 
-      val failureJob = modelConfig.environments("dev").after_deploy.get.on_failure.get
+      val failureJob =
+        modelConfig.environments("dev").after_deploy.get.on_failure.get
 
       failureJob.service_name shouldEqual "jobFailure"
       failureJob.tag shouldEqual Some("jobFailureTag")
     }
 
     "return a value for deploy_freeze" in {
-      val parsed_deploy_freeze = YamlParser.parse(YamlExampleWithDeployFreeze, InfoLogger).asInstanceOf[ValidYaml]
-      val parsed_without_deploy_freeze = YamlParser.parse(YamlExampleWithoutDeployFreeze, InfoLogger).asInstanceOf[ValidYaml]
+      val parsed_deploy_freeze = YamlParser
+        .parse(YamlExampleWithDeployFreeze, InfoLogger)
+        .asInstanceOf[ValidYaml]
+      val parsed_without_deploy_freeze = YamlParser
+        .parse(YamlExampleWithoutDeployFreeze, InfoLogger)
+        .asInstanceOf[ValidYaml]
 
-      parsed_deploy_freeze.config.environments.get("dev").get.container.deploy_freeze shouldEqual Some(true)
-      parsed_without_deploy_freeze.config.environments.get("dev").get.container.deploy_freeze shouldEqual None
+      parsed_deploy_freeze.config.environments
+        .get("dev")
+        .get
+        .container
+        .deploy_freeze shouldEqual Some(true)
+      parsed_without_deploy_freeze.config.environments
+        .get("dev")
+        .get
+        .container
+        .deploy_freeze shouldEqual None
     }
   }
 }
@@ -155,33 +220,84 @@ trait YmlTestFixtures {
       |      url: http://localhost:7099/singularity
       |""".stripMargin
 
-  def YamlInvalidRandom = Source.fromURL(getClass.getResource("/config/invalid-random.yml")).mkString
+  def YamlInvalidRandom =
+    Source.fromURL(getClass.getResource("/config/invalid-random.yml")).mkString
 
-  def YamlInvalidWithoutVersion = Source.fromURL(getClass.getResource("/config/invalid-without-version.yml")).mkString
+  def YamlInvalidWithoutVersion =
+    Source
+      .fromURL(getClass.getResource("/config/invalid-without-version.yml"))
+      .mkString
 
-  def YamlInvalidWithIncompleteConf = Source.fromURL(getClass.getResource("/config/invalid-with-incomplete-conf.yml")).mkString
+  def YamlInvalidWithIncompleteConf =
+    Source
+      .fromURL(getClass.getResource("/config/invalid-with-incomplete-conf.yml"))
+      .mkString
 
-  def YamlExampleValid = Source.fromURL(getClass.getResource("/config/example-config.yml")).mkString
+  def YamlExampleValid =
+    Source.fromURL(getClass.getResource("/config/example-config.yml")).mkString
 
-  def YamlExampleExecutorEnvs = Source.fromURL(getClass.getResource("/config/example-config-with-executor.yml")).mkString
+  def YamlExampleExecutorEnvs =
+    Source
+      .fromURL(getClass.getResource("/config/example-config-with-executor.yml"))
+      .mkString
 
-  def YamlExampleAfterDeploy = Source.fromURL(getClass.getResource("/config/example-config-with-after-deploy.yml")).mkString
+  def YamlExampleAfterDeploy =
+    Source
+      .fromURL(
+        getClass.getResource("/config/example-config-with-after-deploy.yml")
+      )
+      .mkString
 
-  def YamlJobExampleValid = Source.fromURL(getClass.getResource("/config/example-without-optional-config.yml")).mkString
+  def YamlJobExampleValid =
+    Source
+      .fromURL(
+        getClass.getResource("/config/example-without-optional-config.yml")
+      )
+      .mkString
 
-  def YamlExamplePortConfig = Source.fromURL(getClass.getResource("/config/example-port-config.yml")).mkString
+  def YamlExamplePortConfig =
+    Source
+      .fromURL(getClass.getResource("/config/example-port-config.yml"))
+      .mkString
 
-  def YamlExamplePortConfigAllVariations = Source.fromURL(getClass.getResource("/config/example-port-config-all-variations.yml")).mkString
+  def YamlExamplePortConfigAllVariations =
+    Source
+      .fromURL(
+        getClass.getResource("/config/example-port-config-all-variations.yml")
+      )
+      .mkString
 
-  def YamlInvalidPortConfig = Source.fromURL(getClass.getResource("/config/invalid-port-config.yml")).mkString
+  def YamlInvalidPortConfig =
+    Source
+      .fromURL(getClass.getResource("/config/invalid-port-config.yml"))
+      .mkString
 
-  def YamlInvalidPortMapConfig = Source.fromURL(getClass.getResource("/config/invalid-port-map-config.yml")).mkString
+  def YamlInvalidPortMapConfig =
+    Source
+      .fromURL(getClass.getResource("/config/invalid-port-map-config.yml"))
+      .mkString
 
-  def YamlMesosAttributeConfig = Source.fromURL(getClass.getResource("/config/example-mesos-attribute-config.yml")).mkString
+  def YamlMesosAttributeConfig =
+    Source
+      .fromURL(
+        getClass.getResource("/config/example-mesos-attribute-config.yml")
+      )
+      .mkString
 
-  def YamlExampleWithDeployFreeze = Source.fromURL(getClass.getResource("/config/example-config-deploy-freeze.yml")).mkString
+  def YamlExampleWithDeployFreeze =
+    Source
+      .fromURL(getClass.getResource("/config/example-config-deploy-freeze.yml"))
+      .mkString
 
-  def YamlExampleWithoutDeployFreeze = Source.fromURL(getClass.getResource("/config/example-config.yml")).mkString
+  def YamlExampleWithoutDeployFreeze =
+    Source.fromURL(getClass.getResource("/config/example-config.yml")).mkString
 
-  def YamlEnvVarExampleValid = Source.fromURL(getClass.getResource("/config/example-without-optional-envvar-config.yml")).mkString
+  def YamlEnvVarExampleValid =
+    Source
+      .fromURL(
+        getClass.getResource(
+          "/config/example-without-optional-envvar-config.yml"
+        )
+      )
+      .mkString
 }

--- a/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/sidecar/SidecarUtilsSpec.scala
@@ -1,7 +1,7 @@
 package com.nitro.nmesos.sidecar
 
 import org.specs2.mutable.Specification
-import com.nitro.nmesos.util.{ Logger, CustomLogger }
+import com.nitro.nmesos.util.{Logger, CustomLogger}
 
 class SidecarUtilsSpec extends Specification {
 
@@ -11,12 +11,29 @@ class SidecarUtilsSpec extends Specification {
     "diff the infos right" in {
       val containerNotDepoyedOnMesos = Seq()
       val goodContainerInfo, goodSidecarInfo = Seq("image @ host")
-      val badContainerInfo, badSidecarInfo = Seq("image @ host", "image @ host2")
+      val badContainerInfo, badSidecarInfo =
+        Seq("image @ host", "image @ host2")
 
-      SidecarUtils.diffInfo(goodContainerInfo, goodSidecarInfo, "service") should beTrue
-      SidecarUtils.diffInfo(containerNotDepoyedOnMesos, goodSidecarInfo, "service") should beTrue
-      SidecarUtils.diffInfo(goodContainerInfo, badSidecarInfo, "service") should beFalse
-      SidecarUtils.diffInfo(badContainerInfo, goodSidecarInfo, "service") should beFalse
+      SidecarUtils.diffInfo(
+        goodContainerInfo,
+        goodSidecarInfo,
+        "service"
+      ) should beTrue
+      SidecarUtils.diffInfo(
+        containerNotDepoyedOnMesos,
+        goodSidecarInfo,
+        "service"
+      ) should beTrue
+      SidecarUtils.diffInfo(
+        goodContainerInfo,
+        badSidecarInfo,
+        "service"
+      ) should beFalse
+      SidecarUtils.diffInfo(
+        badContainerInfo,
+        goodSidecarInfo,
+        "service"
+      ) should beFalse
     }
   }
 }

--- a/shared/src/test/scala/com/nitro/nmesos/singularity/ModelConversionsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/singularity/ModelConversionsSpec.scala
@@ -7,9 +7,13 @@ class ModelConversionsSpec extends Specification {
   "Singularity Model Conversion" should {
 
     "Return a normalized compatible with Singularity" in {
-      ModelConversions.normalizeId("1.0.98_19f258e") must be equalTo "1_0_98_19f258e"
+      ModelConversions.normalizeId(
+        "1.0.98_19f258e"
+      ) must be equalTo "1_0_98_19f258e"
       ModelConversions.normalizeId("latest") must be equalTo "latest"
-      ModelConversions.normalizeId("2.1.43-Play258") must be equalTo "2_1_43_Play258"
+      ModelConversions.normalizeId(
+        "2.1.43-Play258"
+      ) must be equalTo "2_1_43_Play258"
     }
 
   }

--- a/shared/src/test/scala/com/nitro/nmesos/util/VersionUtilSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/util/VersionUtilSpec.scala
@@ -10,8 +10,12 @@ class VersionUtilSpec extends Specification {
 
     "extract an expected version" in {
       VersionUtil.tryExtract("0.2.1") must be equalTo Success(List(0, 2, 1))
-      VersionUtil.tryExtract("1.0.1-SNAPSHOT") must be equalTo Success(List(1, 0, 1))
-      VersionUtil.tryExtract("nmesos_version: '1.2.3' ## Min nmesos required to execute this config") must be equalTo Success(List(1, 2, 3))
+      VersionUtil.tryExtract("1.0.1-SNAPSHOT") must be equalTo Success(
+        List(1, 0, 1)
+      )
+      VersionUtil.tryExtract(
+        "nmesos_version: '1.2.3' ## Min nmesos required to execute this config"
+      ) must be equalTo Success(List(1, 2, 3))
     }
 
     "extract the version of a yaml file" in {
@@ -23,16 +27,33 @@ class VersionUtilSpec extends Specification {
           |common: &common
           |  image: gonitro/test
         """.stripMargin
-      VersionUtil.tryExtractFromYaml(Yaml) must be equalTo Success(List(2, 0, 3))
+      VersionUtil.tryExtractFromYaml(Yaml) must be equalTo Success(
+        List(2, 0, 3)
+      )
 
     }
 
     "Verify compatible versions" in {
-      VersionUtil.isCompatible(requiredVersion = List(0, 0, 1), installedVersion = List(0, 1, 0)) must beTrue
-      VersionUtil.isCompatible(requiredVersion = List(0, 0, 1), installedVersion = List(0, 0, 1)) must beTrue
-      VersionUtil.isCompatible(requiredVersion = List(0, 0, 2), installedVersion = List(0, 0, 1)) must beFalse
-      VersionUtil.isCompatible(requiredVersion = List(0, 1, 0), installedVersion = List(0, 1, 0)) must beTrue
-      VersionUtil.isCompatible(requiredVersion = List(1, 1, 0), installedVersion = List(1, 1, 10)) must beTrue
+      VersionUtil.isCompatible(
+        requiredVersion = List(0, 0, 1),
+        installedVersion = List(0, 1, 0)
+      ) must beTrue
+      VersionUtil.isCompatible(
+        requiredVersion = List(0, 0, 1),
+        installedVersion = List(0, 0, 1)
+      ) must beTrue
+      VersionUtil.isCompatible(
+        requiredVersion = List(0, 0, 2),
+        installedVersion = List(0, 0, 1)
+      ) must beFalse
+      VersionUtil.isCompatible(
+        requiredVersion = List(0, 1, 0),
+        installedVersion = List(0, 1, 0)
+      ) must beTrue
+      VersionUtil.isCompatible(
+        requiredVersion = List(1, 1, 0),
+        installedVersion = List(1, 1, 10)
+      ) must beTrue
     }
   }
 }


### PR DESCRIPTION
This PR would implement the feature `run-local`, which essentially just parses the yaml file and uses the env-vars from `dev` in order to do a `docker run -i p port:port -e env_var1=env_var1.... service_name`.

I also took the liberty to finish the upgrade to scalafmt: We still had `scalariform` as formatting tool, but we were already specifying scalafmt config. This should fix the transition :)

This PR is divided into 3 parts as you can see in the commits:
1. fully transition to `scalafmt`
2. re-format everything
3. implement the feature

For the reviewer, going through the 3 commits might be best strategy to distinguish between formatting and the new feature.
