### PR TITLE
Fix parsing problem for Locale.CANADA (Java > 1.8).

### DIFF
--- a/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
+++ b/shared/src/main/scala/com/nitro/nmesos/config/Validations.scala
@@ -85,7 +85,7 @@ object Validations extends ValidationHelper {
   def processLine(line: String): (String, LocalDate) = {
     val p = raw"^\s*([A-Z0-9_]+):.*# @deprecated-on (.*)".r
     val p(envVar, date) = line
-    val deprecatedOn = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+    val deprecatedOn = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MMM-yyyy", ju.Locale.US))
     (envVar, deprecatedOn)
   }
 

--- a/shared/src/test/scala/com/nitro/nmesos/config/ValidationsSpec.scala
+++ b/shared/src/test/scala/com/nitro/nmesos/config/ValidationsSpec.scala
@@ -3,6 +3,9 @@ package com.nitro.nmesos.config
 import org.specs2.mutable.Specification
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.{ util => ju }
+import _root_.java.{ util => ju }
+import _root_.java.{ util => ju }
 
 /*
  * Test the (basic) Validations
@@ -67,7 +70,7 @@ class ValidationsSpec extends Specification {
   "Validations checkDeprecated" should {
 
     "succeed if no env_vars are expired" in {
-      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy", ju.Locale.US))
       val expectedResult = Seq(
         Ok("Deprecated Env Var - OLD_ENV_VAR_10"),
         Ok("Deprecated Env Var - OLD_ENV_VAR_20"),
@@ -76,7 +79,7 @@ class ValidationsSpec extends Specification {
     }
 
     "fail/warn if env_vars are expired" in {
-      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+      val today = LocalDate.parse("30-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy", ju.Locale.US))
       val expectedResult = Seq(
         Fail("Deprecated Env Var - OLD_ENV_VAR_10", "< 20"),
         Warning("Deprecated Env Var - OLD_ENV_VAR_20", "< 10"),
@@ -90,7 +93,7 @@ class ValidationsSpec extends Specification {
 
     "succeed, if a well formed line needs to get processes" in {
       val line = "OLD_ENV_VAR_10: \"old value\" # @deprecated-on 10-Jan-2020"
-      val expectedDate = LocalDate.parse("10-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy"))
+      val expectedDate = LocalDate.parse("10-Jan-2020", DateTimeFormatter.ofPattern("dd-MMM-yyyy", ju.Locale.US))
       Validations.processLine(line) should be equalTo ("OLD_ENV_VAR_10", expectedDate)
     }
 


### PR DESCRIPTION
This is a good one ...

The was a bug in Java 8, which made the old implementation work by accident - https://bugs.openjdk.java.net/browse/JDK-8206980.

This bug was fixed in Java 9 and beyond. With that bug-fix nmesos fails to parse the date in most Locales other than US.

I was able to reproduce this by running nmesis with Java 14 and forcing the parser to use Locale.CANADA.

Hardcoding Locale.US while parsing the date fixes the problem.