### PR TITLE
Retire dryrun for good

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.0.7 (2023-01-01)
+
+* Remove the `dryrun` flag for good (please use `dry-run` instead)
+
 ## 3.0.6 (2022-10-01)
 
 * Upgrade to Scala 3.2.0

--- a/src/main/scala/ninesstack/nmesos/cli/CliParser.scala
+++ b/src/main/scala/ninesstack/nmesos/cli/CliParser.scala
@@ -85,11 +85,6 @@ object CliParser {
           .text("Force action!!!}")
           .optional()
           .action((input, params) => params.copy(force = true)),
-        opt[Boolean]("dryrun")
-          .abbr("x")
-          .text("Deprecated. Will be removed soon.")
-          .optional()
-          .action((input, params) => params.copy(isDryrun = input)),
         opt[Boolean]("dry-run")
           .abbr("n")
           .text(s"Is this a dry run? Default: ${DefaultValues.IsDryRun}")


### PR DESCRIPTION
## What/Why?

* `dryrun` got replaced with `dry-run`
* (finally) removing support for the `dryrun` flag